### PR TITLE
Add lint-on-save hook to automatically format and check Python files

### DIFF
--- a/.claude/hooks/lint-on-save.py
+++ b/.claude/hooks/lint-on-save.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Post-tool hook: Run formatter and type checker on Python files after Edit/Write.
+
+Triggered after Edit or Write tools modify files.
+Runs ruff (format + lint) and ty (type check) on Python files.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def get_file_path() -> str | None:
+    """Extract file path from tool input."""
+    tool_input = os.environ.get("CLAUDE_TOOL_INPUT", "")
+    if not tool_input:
+        return None
+
+    try:
+        data = json.loads(tool_input)
+        return data.get("file_path")
+    except json.JSONDecodeError:
+        return None
+
+
+def is_python_file(path: str) -> bool:
+    """Check if the file is a Python file."""
+    return path.endswith(".py")
+
+
+def run_command(cmd: list[str], cwd: str) -> tuple[int, str, str]:
+    """Run a command and return (returncode, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return 1, "", "Command timed out"
+    except FileNotFoundError:
+        return 1, "", f"Command not found: {cmd[0]}"
+
+
+def main() -> None:
+    file_path = get_file_path()
+    if not file_path:
+        return
+
+    if not is_python_file(file_path):
+        return
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+
+    # Determine relative path for display
+    if file_path.startswith(project_dir):
+        rel_path = os.path.relpath(file_path, project_dir)
+    else:
+        rel_path = file_path
+
+    issues: list[str] = []
+
+    # Run ruff format
+    ret, stdout, stderr = run_command(
+        ["uv", "run", "ruff", "format", file_path],
+        cwd=project_dir,
+    )
+    if ret != 0:
+        issues.append(f"ruff format failed:\n{stderr or stdout}")
+
+    # Run ruff check with auto-fix
+    ret, stdout, stderr = run_command(
+        ["uv", "run", "ruff", "check", "--fix", file_path],
+        cwd=project_dir,
+    )
+    if ret != 0:
+        # Show remaining issues that couldn't be auto-fixed
+        output = stdout or stderr
+        if output.strip():
+            issues.append(f"ruff check issues:\n{output}")
+
+    # Run ty type check
+    ret, stdout, stderr = run_command(
+        ["uv", "run", "ty", "check", file_path],
+        cwd=project_dir,
+    )
+    if ret != 0:
+        output = stdout or stderr
+        if output.strip():
+            issues.append(f"ty check issues:\n{output}")
+
+    # Report results
+    if issues:
+        print(f"[lint-on-save] Issues found in {rel_path}:", file=sys.stderr)
+        for issue in issues:
+            print(issue, file=sys.stderr)
+        print(
+            "\nPlease review and fix these issues.",
+            file=sys.stderr,
+        )
+    else:
+        print(f"[lint-on-save] ✓ {rel_path} passed all checks")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/lint-on-save.py\"",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-implementation-review.py\"",
             "timeout": 10
           }


### PR DESCRIPTION
## Summary
This PR adds an automated linting and formatting workflow that runs on every Python file modification. A new post-tool hook executes `ruff` (for formatting and linting) and `ty` (for type checking) whenever files are edited or written through Claude's tools.

## Changes
- **New hook script** (`.claude/hooks/lint-on-save.py`): Post-tool hook that automatically runs code quality checks on modified Python files
  - Extracts file path from tool input and validates it's a Python file
  - Runs `ruff format` to auto-format code
  - Runs `ruff check --fix` to auto-fix linting issues
  - Runs `ty check` for type checking
  - Reports any remaining issues that couldn't be auto-fixed
  - Includes proper error handling and timeout management (30s)

- **Updated settings** (`.claude/settings.json`): Registered the new hook to trigger after Edit/Write tool operations

## Implementation Details
- The hook gracefully handles missing tools and timeouts without blocking the workflow
- Only processes Python files (`.py` extension)
- Uses `uv run` to execute tools, ensuring consistent environment
- Provides clear feedback with relative file paths and categorized issue reporting
- Runs with a 30-second timeout to prevent hanging operations

https://claude.ai/code/session_018BUhS5nWMmHX4KAUYzLb4R