### PR TITLE
Fix markdown image syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-code-orchestra
 
-![]("/summary.png")
+![Claude Code Orchestra](./summary.png)
 
 Multi-Agent AI Development Environment
 


### PR DESCRIPTION
## Summary
Fixed the markdown image syntax in the README.md file to properly display the summary image.

## Changes
- Corrected the image markdown from `![]("/summary.png")` to `![Claude Code Orchestra](./summary.png)`
  - Removed unnecessary quotes around the image path
  - Added descriptive alt text "Claude Code Orchestra"
  - Changed path from absolute-style to relative path notation for better portability

## Details
The previous syntax had the image path wrapped in quotes within the parentheses, which is invalid markdown. The corrected syntax follows standard markdown image format: `![alt text](image path)`, ensuring the image displays correctly in the repository.

https://claude.ai/code/session_015DcwRYbp6twxM3B8uKAoCc