### PR TITLE
Set fastMode to false by default to avoid 6x cost increase

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "$schema": "https://code.claude.com/schemas/settings.json",
   "language": "japanese",
   "effortLevel": "high",
-  "fastMode": true,
+  "fastMode": false,
   "alwaysThinkingEnabled": true,
   "hooks": {
     "UserPromptSubmit": [


### PR DESCRIPTION
Fast mode can be toggled on-demand with /fast when needed for interactive work like rapid iteration or live debugging.

https://claude.ai/code/session_0157UpWkqRi6Nz4h5g8PCUtN