### PR TITLE
Update Claude settings schema URL to use schemastore.org

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://code.claude.com/schemas/settings.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "language": "japanese",
   "effortLevel": "high",
   "fastMode": false,


### PR DESCRIPTION
## Summary
Updated the JSON schema reference in the Claude settings configuration to use the standardized schema store URL instead of the internal code.claude.com endpoint.

## Changes
- Updated `$schema` field in `.claude/settings.json` from `https://code.claude.com/schemas/settings.json` to `https://json.schemastore.org/claude-code-settings.json`

## Details
This change improves schema validation by using the community-maintained JSON Schema Store (schemastore.org), which provides better IDE support and ensures the schema definition is publicly accessible and version-controlled. This is a standard practice for JSON schema references and improves the development experience across different editors and tools.

https://claude.ai/code/session_01PjWENrp5bcWgBxgqqwm8s9