### PR TITLE
Fix outdated Codex `web_search` value in .codex/config.toml

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,7 +7,7 @@ model_reasoning_effort = "xhigh"
 model_reasoning_summary = "detailed"
 
 # Web search
-web_search = "enabled"
+web_search = "live"
 
 # Approval policy
 approval_policy = "on-request"


### PR DESCRIPTION
## Summary

This PR updates the Codex template config to use the current `web_search` value.

- `web_search = "enabled"` -> `web_search = "live"`

## Why

With recent Codex CLI versions, `enabled` is no longer accepted for `web_search`.
The CLI expects values like `disabled`, `cached`, or `live`, so the current template can fail on startup.

## Impact

This repository is used as a template and `.codex/` is copied into user projects in the Quick Start flow, so this outdated value propagates to new setups.

## Notes

I only changed the `web_search` value.
I did not touch other `enabled` keys (e.g. `[[skills.config]] enabled = true`) because they are unrelated.