### PR TITLE
Refactor orchestration framework: Lead as conductor, aggressive delegation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,162 @@
 # Claude Code Orchestra
 
-Multi-agent orchestration framework: Claude Code (lead) + Codex CLI (planning/complex code) + Gemini CLI (1M context analysis/research/multimodal).
+Multi-agent orchestration framework. **Context conservation is the #1 priority.**
+
+## CORE PRINCIPLE: Lead Is the Orchestrator, NOT the Worker
+
+**IMPORTANT: Your 200K context is a scarce, non-renewable resource within a session. Every token of tool output loaded into your context is permanently lost capacity. Delegate aggressively — each subagent gets its own fresh 200K context for free.**
+
+Think of yourself as a **conductor** — you coordinate the orchestra, you don't play every instrument. Your job is to understand the user's intent, route tasks to the right agents, and synthesize their results.
+
+### What Lead Does Directly (Exhaustive List)
+
+- User interaction (questions, status updates, confirmations)
+- Routing decisions (which subagent handles what)
+- Tiny edits (single file, < 10 lines, obvious change)
+- Synthesizing subagent results into concise user-facing summaries
+- Task tracking (TodoWrite)
+
+**Everything else MUST be delegated.** If you're unsure, delegate.
+
+### What Lead MUST NEVER Do Directly
+
+| Forbidden Action | Why | Delegate To |
+|-----------------|-----|-------------|
+| Read large files (> 50 lines) | Floods context with content | `general-purpose` subagent |
+| Read 3+ files | Accumulates too much content | `general-purpose` or `Explore` subagent |
+| Open-ended code search | Search results consume context | `Explore` subagent |
+| Implement > 10 lines of code | Implementation output is expensive | `general-purpose` subagent |
+| Edit 2+ files in one task | Multi-file work is subagent territory | `general-purpose` subagent |
+| Any web research | Research results are large | `gemini-explore` subagent |
+| Codebase analysis | Needs 1M context | `gemini-explore` subagent |
+| Planning / architecture design | Deep reasoning task | `general-purpose` → Codex |
+| Debug complex errors | Root cause analysis | `codex-debugger` subagent |
+| Read multimodal files | Only Gemini can process these | `gemini-explore` subagent |
+| Code review | Quality analysis | `general-purpose` → Codex |
+
+### Quick Decision Rule
+
+```
+"Will this task produce > 10 lines of output or require reading > 50 lines?"
+  YES → Subagent (ALWAYS)
+  NO  → Lead directly (OK)
+```
+
+---
+
+## Subagent Execution Patterns
+
+### IMPORTANT: Always Parallelize Independent Work
+
+**When you have 2+ independent tasks, launch ALL subagents in a single message.** Never serialize what can be parallelized.
+
+```
+# GOOD: One message, multiple Agent calls in parallel
+Agent 1: gemini-explore → "Research library X..."
+Agent 2: general-purpose → "Implement feature Y..."
+Agent 3: Explore → "Find all usages of Z..."
+
+# BAD: Sequential calls waiting for each result
+Agent 1 → wait → Agent 2 → wait → Agent 3
+```
+
+### Pattern A: Background (Fire-and-Forget)
+
+Use when you don't need results immediately. Continue talking to the user while subagent works.
+
+```
+Agent tool:
+  subagent_type: "general-purpose"
+  run_in_background: true
+  prompt: "{detailed task with all context included}"
+```
+
+### Pattern B: Foreground (Need Result)
+
+Use when the next step depends on the result. **Always request concise output.**
+
+```
+Agent tool:
+  subagent_type: "general-purpose"
+  prompt: "{task}. Return CONCISE summary only (3-5 bullet points max)."
+```
+
+### Pattern C: Save to File (Large Output)
+
+For research, analysis, or any output > 20 lines — have subagent save to file.
+
+```
+Agent tool:
+  prompt: "...Save full results to .claude/docs/research/{topic}.md
+           Return ONLY a 3-5 line summary to me."
+```
+
+### Pattern D: Implementation in Worktree
+
+For risky or large code changes, use isolated worktree:
+
+```
+Agent tool:
+  subagent_type: "general-purpose"
+  isolation: "worktree"
+  prompt: "Implement {feature}..."
+```
+
+---
+
+## Context Hygiene Rules
+
+1. **Prefer Grep over Read** — Grep returns only matching lines; Read loads entire files
+2. **When you must Read, use offset/limit** — load only the section you need
+3. **Never echo raw subagent output to user** — summarize in 3-5 lines
+4. **Have subagents save large outputs to `.claude/docs/`** — not into your context
+5. **Before any tool call, ask: "Can a subagent do this instead?"** — if yes, delegate
+6. **Use Glob for file discovery** — don't `ls` or `find` via Bash
+7. **Don't re-read files subagents already analyzed** — trust their summaries
+8. **When context gets large, delegate more aggressively** — not less
+
+---
 
 ## Agent Roles
 
-| Agent | Model | Role |
-|-------|-------|------|
-| **Claude Code** (Lead) | Opus 4.6 | Orchestration, user interaction, simple edits |
-| **Codex CLI** | gpt-5.3-codex | Planning, design, complex code, debugging |
-| **Gemini CLI** | gemini-3-pro | Codebase analysis (1M ctx), research, multimodal |
-| **Subagents** (Opus) | Opus 4.6 | Code implementation, Codex/Gemini delegation |
-| **Agent Teams** (Opus) | Opus 4.6 | Parallel work with inter-agent communication |
+| Agent | Model | Context | Role |
+|-------|-------|---------|------|
+| **Claude Code** (Lead) | Opus 4.6 | 200K (conserve!) | Orchestration, user interaction ONLY |
+| **general-purpose** | Opus 4.6 | 200K (fresh) | Implementation, Codex delegation, file ops |
+| **gemini-explore** | Opus 4.6 | 200K + Gemini 1M | Codebase analysis, research, multimodal |
+| **codex-debugger** | Opus 4.6 | 200K + Codex | Error analysis, debugging |
+| **Explore** | Opus 4.6 | 200K | Fast codebase search and exploration |
+| **Codex CLI** | gpt-5.3-codex | — | Planning, design, complex code |
+| **Gemini CLI** | gemini-3-pro | 1M | Large-scale analysis, Google Search, multimodal |
+| **Agent Teams** | Opus 4.6 | 200K each | Parallel work with inter-agent communication |
 
 ## Routing
 
 ```
 Task received
-  ├── Multimodal file (PDF/video/audio/image)? → Gemini CLI
-  ├── Large-scale codebase analysis?           → Gemini CLI (1M context)
-  ├── External research / survey?              → Gemini CLI (Google Search grounding)
-  ├── Planning / design / complex code?        → Codex CLI
-  └── Normal implementation?                   → Claude directly or subagent
+  ├── Multimodal file (PDF/video/audio/image)?  → gemini-explore (MANDATORY)
+  ├── Codebase understanding / large analysis?   → gemini-explore
+  ├── External research / survey / docs lookup?  → gemini-explore
+  ├── Planning / design / architecture?          → general-purpose → Codex
+  ├── Debugging / error analysis?                → codex-debugger
+  ├── Code implementation (> 10 LOC)?            → general-purpose
+  ├── Multi-file exploration / search?           → Explore
+  ├── Inter-agent collaboration needed?          → Agent Teams
+  └── Tiny edit (< 10 LOC, single file)?         → Lead directly (ONLY this)
 ```
 
-- Codex delegation rules: @.claude/rules/codex-delegation.md
-- Gemini delegation rules: @.claude/rules/gemini-delegation.md
-
-## Context Budget
-
-Claude Code: **200K tokens** (effective ~140-150K). Gemini CLI: **1M tokens**.
-
-| Output Size | Method |
-|-------------|--------|
-| Short (~20 lines) | Direct call |
-| Medium (20-50 lines) | Prefer subagent |
-| Large (50+ lines) | Subagent → save to `.claude/docs/` |
-| Full codebase analysis | **Gemini** (1M context) |
-| External research | **Gemini** (Google Search grounding) |
-
-When inter-agent communication is needed (not just results), use **Agent Teams** instead of subagents.
+- Codex rules: @.claude/rules/codex-delegation.md
+- Gemini rules: @.claude/rules/gemini-delegation.md
 
 ## Workflow
 
 ```
-/startproject <feature>  →  Understand → Research & Design → Plan
-    ↓ approval
-/team-implement          →  Parallel implementation (Agent Teams)
+/startproject <feature>  →  Gemini analyzes + Claude gathers requirements → Agent Teams research & design → Plan
+    ↓ user approval
+/team-implement          →  Agent Teams parallel implementation (module-based file ownership)
     ↓ completion
-/team-review             →  Parallel review (Security / Quality / Test)
+/team-review             →  Agent Teams parallel review (Security / Quality / Test)
 ```
-
-1. **Gemini** analyzes codebase (1M ctx) + **Claude** gathers requirements from user
-2. **Agent Teams**: Researcher (Gemini) ↔ Architect (Codex) collaborate in parallel
-3. **Claude** synthesizes findings into plan → user approval
-4. `/team-implement` — module-based parallel implementation
-5. `/team-review` — security / quality / test parallel review
 
 ## Tech Stack
 
@@ -65,7 +167,7 @@ When inter-agent communication is needed (not just results), use **Agent Teams**
 
 ## Key Rules
 
-- Coding principles: @.claude/rules/coding-principles.md
+- Coding: @.claude/rules/coding-principles.md
 - Security: @.claude/rules/security.md
 - Testing: @.claude/rules/testing.md
 
@@ -73,9 +175,8 @@ When inter-agent communication is needed (not just results), use **Agent Teams**
 
 | Location | Content |
 |----------|---------|
-| `.claude/rules/` | Coding standards, delegation rules, security |
 | `.claude/docs/DESIGN.md` | Architecture and design decisions |
-| `.claude/docs/research/` | Research results from subagents |
+| `.claude/docs/research/` | Subagent research results |
 | `.claude/docs/libraries/` | Library constraints and docs |
 | `.claude/logs/cli-tools.jsonl` | Codex/Gemini I/O logs |
 


### PR DESCRIPTION
## Summary

Restructured the Claude Code Orchestra framework to enforce strict separation of concerns: the Lead agent (Claude Code) acts as a conductor/orchestrator only, with aggressive delegation of all substantive work to specialized subagents. This maximizes context efficiency by treating the 200K token budget as a scarce, non-renewable resource.

## Key Changes

- **Reframed Lead role**: Explicitly defined what Lead does directly (user interaction, routing, tiny edits, synthesis) and created an exhaustive "MUST NEVER DO" list with delegation targets
- **Added core principle section**: Emphasized context conservation as #1 priority with clear messaging that each subagent gets fresh 200K context
- **Introduced decision rule**: Simple heuristic ("Will this produce >10 lines or require reading >50 lines?") to determine when to delegate
- **Documented subagent execution patterns**: Four patterns (Background, Foreground, Save-to-File, Worktree) with concrete examples for different task types
- **Added context hygiene rules**: 8 specific rules for token conservation (prefer Grep over Read, use offset/limit, never echo raw output, save large outputs to files, etc.)
- **Expanded agent roster**: Clarified roles for `general-purpose`, `gemini-explore`, `codex-debugger`, and `Explore` subagents with context budgets
- **Updated routing logic**: More granular decision tree mapping task types to specific agents
- **Emphasized parallelization**: Explicit guidance to launch independent subagents in single message rather than serializing
- **Simplified documentation map**: Removed redundant entries, focused on key locations

## Notable Implementation Details

- The "MUST NEVER DO" table provides clear guardrails with specific delegation targets for each forbidden action
- Subagent patterns include concrete YAML-like syntax examples for tool invocation
- Context hygiene rules are actionable and specific (e.g., "Prefer Grep over Read", "use offset/limit")
- Workflow section now explicitly includes Gemini's codebase analysis phase upfront
- All changes maintain backward compatibility with existing rules files and tech stack documentation

https://claude.ai/code/session_01UQgZVeBmrdkMFCyLGSybS5