### PR TITLE
Upgrade Codex integration to gpt-5.4, add Codex handoff playbook, and update delegation/config

### DIFF
--- a/.claude/agents/codex-debugger.md
+++ b/.claude/agents/codex-debugger.md
@@ -30,7 +30,7 @@ Before calling Codex, gather relevant context:
 ### Step 2: Call Codex CLI
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox workspace-write --full-auto "
+codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
 Analyze this error and provide root cause + fix:
 
 ## Error Output

--- a/.claude/agents/general-purpose.md
+++ b/.claude/agents/general-purpose.md
@@ -33,10 +33,10 @@ When planning, design decisions, debugging, or complex implementation is needed:
 
 ```bash
 # Analysis (read-only)
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "{question}" 2>/dev/null
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "{question}" 2>/dev/null
 
 # Implementation work (can write files)
-codex exec --model gpt-5.3-codex --sandbox workspace-write --full-auto "{task}" 2>/dev/null
+codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "{task}" 2>/dev/null
 ```
 
 **When to call Codex:**

--- a/.claude/docs/CODEX_HANDOFF_PLAYBOOK.md
+++ b/.claude/docs/CODEX_HANDOFF_PLAYBOOK.md
@@ -1,0 +1,97 @@
+# Codex Handoff Playbook
+
+This document standardizes how Claude Code hands tasks to Codex so planning/implementation loops stay short and predictable.
+
+## Goals
+
+- Reduce retries caused by ambiguous Codex prompts.
+- Keep Claude context small by returning concise summaries.
+- Make Codex responses immediately actionable in Claude workflows.
+
+## 1) Delegation Decision Matrix
+
+Use Codex when **at least one** is true:
+
+- Architecture or module boundary decisions are involved.
+- The implementation requires multiple dependent steps.
+- The error root cause is unknown.
+- Trade-off comparison is required.
+- The change affects 2+ files with behavioral impact.
+
+Skip Codex when all are true:
+
+- Single-file, obvious edit.
+- <10 LOC change.
+- No design decision or risk.
+
+## 2) Prompt Contract (Required Fields)
+
+Every Codex prompt should include:
+
+1. **Objective**: one-sentence outcome.
+2. **Constraints**: language, style, forbidden approaches.
+3. **Relevant files**: explicit paths.
+4. **Acceptance checks**: commands to run.
+5. **Output format**: concise markdown sections.
+
+## 3) Recommended Prompt Templates
+
+### A. Planning / Design (read-only)
+
+```bash
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+Objective: Create an implementation plan for {feature}.
+Constraints:
+- Keep existing architecture unless explicitly justified.
+- Prefer minimal diff.
+Relevant files:
+- {file1}
+- {file2}
+Acceptance checks:
+- {test or lint commands}
+Output format:
+## Analysis
+## Recommendation
+## Implementation Plan
+## Risks
+## Next Steps
+"
+```
+
+### B. Complex Implementation (workspace-write)
+
+```bash
+codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+Objective: Implement {feature/fix}.
+Constraints:
+- Follow project lint/type/test rules.
+- Do not modify unrelated files.
+Relevant files:
+- {file1}
+- {file2}
+Acceptance checks:
+- {test or lint commands}
+Output format:
+## Changes Made
+## Validation
+## Remaining Risks
+"
+```
+
+## 4) Claude-side Compression Rules
+
+When Codex finishes, Claude should keep only:
+
+- Top recommendation.
+- 3-5 implementation steps.
+- Risks requiring user decision.
+
+Store long analysis in `.claude/docs/research/` and reference the path in user-facing updates.
+
+## 5) Failure Recovery
+
+If Codex output is not actionable:
+
+1. Re-run with explicit file list and acceptance checks.
+2. Split into two calls: `read-only` plan → `workspace-write` implementation.
+3. Ask Codex to compare exactly two options and choose one.

--- a/.claude/docs/DESIGN.md
+++ b/.claude/docs/DESIGN.md
@@ -24,7 +24,7 @@ Claude Code Orchestra is a multi-agent collaboration framework. Claude Code (200
 │  └──────────────────────┘  └──────────────────────┘             │
 │                                                                   │
 │  External CLIs:                                                   │
-│  ├── Codex CLI (gpt-5.3-codex) — planning, design, complex code  │
+│  ├── Codex CLI (gpt-5.4) — planning, design, complex code  │
 │  └── Gemini CLI (1M context) — codebase analysis, research,      │
 │       multimodal reading                                          │
 └─────────────────────────────────────────────────────────────────┘
@@ -54,7 +54,7 @@ Claude Code Orchestra is a multi-agent collaboration framework. Claude Code (200
 
 | Library | Role | Version | Notes |
 |---------|------|---------|-------|
-| Codex CLI | Planning, design, complex code | gpt-5.3-codex | Architecture, planning, debug, complex implementation |
+| Codex CLI | Planning, design, complex code | gpt-5.4 | Architecture, planning, debug, complex implementation |
 | Gemini CLI | Multimodal file reading | gemini-3-pro | PDF/video/audio/image extraction ONLY |
 
 ### Key Decisions

--- a/.claude/hooks/agent-router.py
+++ b/.claude/hooks/agent-router.py
@@ -146,7 +146,7 @@ def main():
                     "additionalContext": (
                         f"[Agent Routing] Detected '{trigger}' — this task may benefit from "
                         "Codex CLI for planning, design, or complex implementation. Consider: "
-                        "`codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "
+                        "`codex exec --model gpt-5.4 --sandbox read-only --full-auto "
                         '"{task description}"` for design decisions, planning, debugging, '
                         "or complex analysis."
                     )

--- a/.claude/hooks/check-codex-before-write.py
+++ b/.claude/hooks/check-codex-before-write.py
@@ -127,7 +127,7 @@ def main():
                         "**Recommended**: Use Task tool with subagent_type='general-purpose' "
                         "to preserve main context. "
                         "(Direct call OK for quick questions: "
-                        "`codex exec --model gpt-5.3-codex --sandbox read-only --full-auto '...'`)"
+                        "`codex exec --model gpt-5.4 --sandbox read-only --full-auto '...'`)"
                     )
                 }
             }

--- a/.claude/hooks/log-cli-tools.py
+++ b/.claude/hooks/log-cli-tools.py
@@ -99,7 +99,7 @@ def main() -> None:
     if is_codex:
         tool = "codex"
         prompt = extract_codex_prompt(command)
-        model = extract_model(command) or "gpt-5.3-codex"
+        model = extract_model(command) or "gpt-5.4"
     else:
         tool = "gemini"
         prompt = extract_gemini_prompt(command)

--- a/.claude/rules/codex-delegation.md
+++ b/.claude/rules/codex-delegation.md
@@ -18,45 +18,30 @@
 - Advanced refactoring
 - Multi-step implementation tasks
 
-## When to Consult Codex
+## Delegation Decision
 
-| Situation | Examples |
-|------|------|
-| **Planning needed** | "How to design?" "Create a plan" "Architecture" |
-| **Complex implementation** | Complex logic, optimization, performance improvements |
-| **Debugging** | "Why doesn't this work?" "What caused the error?" (after initial failure) |
-| **Comparison and trade-off analysis** | "Which is better, A or B?" "What are the trade-offs?" |
-| **Code review** | "Review this" "Quality check" |
+Default to Codex-first delegation for development tasks.
 
-### Trigger Phrases (User Input)
+Consult Codex when **any** of these apply (recommended default):
 
-| Phrase | English Equivalent |
-|----------|---------|
-| "How should I design/implement?" | "How should I design/implement?" |
-| "Create a plan" "Architecture" | "Create a plan" "Architecture" |
-| "Why doesn't this work?" "What caused it?" "There's an error" | "Why doesn't this work?" "Error" |
-| "Which is better?" "Compare" "Trade-offs?" | "Which is better?" "Compare" |
-| "Think about this" "Analyze" "Think deeper" | "Think" "Analyze" "Think deeper" |
+- Design/architecture decisions are involved.
+- Change spans 2+ files with behavior impact.
+- Root cause is unclear.
+- User requests comparison/trade-off analysis.
+- You need a step-by-step implementation plan.
+- You are unsure and want a safe implementation direction.
 
-## When NOT to Consult
+Skip Codex only for obvious one-file tiny edits.
 
-- Simple file edits (typo fixes, small changes)
-- Tasks that simply follow explicit user instructions
-- Standard operations (git commit, running tests)
-- Tasks with a single clear solution
-- File search and reading
-- **Codebase analysis** -- Claude handles directly (1M context)
-- **External information retrieval** -- Subagent (WebSearch/WebFetch) handles
-- **Multimodal processing** -- Gemini handles
+## Prompt Contract (Always Include)
 
-## Context Management
+1. Objective (single sentence)
+2. Constraints (style, limits, forbidden approaches)
+3. Relevant files (explicit paths)
+4. Acceptance checks (commands)
+5. Output format (structured markdown sections)
 
-| Situation | Recommended Method |
-|------|----------|
-| Short question and answer (~50 lines) | Direct call OK |
-| Detailed design or planning | Via subagent |
-| Debug analysis | Via subagent |
-| Complex code implementation | Via subagent (workspace-write) |
+Detailed templates: `@.claude/docs/CODEX_HANDOFF_PLAYBOOK.md`
 
 ## How to Consult
 
@@ -69,31 +54,47 @@ Task tool parameters:
 - prompt: |
     Consult Codex about: {topic}
 
-    codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "
-    {question for Codex}
+    codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+    Objective: {single-sentence objective}
+    Constraints:
+    - {constraint 1}
+    Relevant files:
+    - {file paths}
+    Acceptance checks:
+    - {commands}
+    Output format:
+    ## Analysis
+    ## Recommendation
+    ## Implementation Plan
+    ## Risks
+    ## Next Steps
     " 2>/dev/null
 
     Return CONCISE summary (key recommendation + rationale).
 ```
 
-### Direct Call (Short questions, ~50 line responses)
+### Direct Call (Short questions only)
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "Brief question" 2>/dev/null
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "Objective: {brief question}" 2>/dev/null
 ```
 
 ### Having Codex Implement Code
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox workspace-write --full-auto "
-Implement: {detailed implementation task}
-
-Requirements:
-- {requirement 1}
-- {requirement 2}
-
-Files to create/modify:
+codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+Objective: Implement {detailed implementation task}
+Constraints:
+- Follow existing project conventions
+- Keep diffs minimal
+Relevant files:
 - {file paths}
+Acceptance checks:
+- {commands}
+Output format:
+## Changes Made
+## Validation
+## Remaining Risks
 " 2>/dev/null
 ```
 

--- a/.claude/skills/codex-system/SKILL.md
+++ b/.claude/skills/codex-system/SKILL.md
@@ -65,7 +65,7 @@ Task tool parameters:
 - prompt: |
     Consult Codex about: {topic}
 
-    codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "
+    codex exec --model gpt-5.4 --sandbox read-only --full-auto "
     {question for Codex}
     " 2>/dev/null
 
@@ -75,13 +75,13 @@ Task tool parameters:
 ### Direct Call (responses up to ~50 lines)
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "Brief question" 2>/dev/null
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "Brief question" 2>/dev/null
 ```
 
 ### Having Codex Implement Code
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox workspace-write --full-auto "
+codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
 Implement: {task description}
 Requirements: {requirements}
 Files: {file paths}
@@ -100,7 +100,7 @@ Files: {file paths}
 ### Implementation Planning
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "
 Create an implementation plan for: {feature}
 
 Context: {relevant architecture/code}
@@ -116,7 +116,7 @@ Provide:
 ### Design Review
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "
 Review this design approach for: {feature}
 
 Context: {relevant code or architecture}
@@ -132,7 +132,7 @@ Evaluate:
 ### Debug Analysis
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "
 Debug this issue:
 
 Error: {error message}

--- a/.claude/skills/codex-system/references/code-review-task.md
+++ b/.claude/skills/codex-system/references/code-review-task.md
@@ -68,7 +68,7 @@ Well-implemented points
 ## Example Invocation
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "
 Review this code change:
 
 ## Changes

--- a/.claude/skills/codex-system/references/refactoring-task.md
+++ b/.claude/skills/codex-system/references/refactoring-task.md
@@ -62,7 +62,7 @@ Provide:
 ## Example Invocation
 
 ```bash
-codex exec --model gpt-5.3-codex --sandbox workspace-write --full-auto "
+codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
 Refactor this code for simplicity:
 
 ## Target Code

--- a/.claude/skills/startproject/SKILL.md
+++ b/.claude/skills/startproject/SKILL.md
@@ -190,7 +190,7 @@ Spawn two teammates:
    4. Identify risks and mitigation strategies
 
    How to consult Codex:
-   codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "{question}" 2>/dev/null
+   codex exec --model gpt-5.4 --sandbox read-only --full-auto "{question}" 2>/dev/null
 
    Update .claude/docs/DESIGN.md with architecture decisions.
 

--- a/.claude/skills/team-review/SKILL.md
+++ b/.claude/skills/team-review/SKILL.md
@@ -123,7 +123,7 @@ Spawn reviewers:
    - Library constraint violations (.claude/docs/libraries/)
 
    Use Codex CLI for deep analysis of complex logic:
-   codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "{question}" 2>/dev/null
+   codex exec --model gpt-5.4 --sandbox read-only --full-auto "{question}" 2>/dev/null
 
    Changed files: {list}
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -54,10 +54,10 @@ You can read project context from `.claude/`:
 
 ```bash
 # Analysis and planning (read-only)
-codex exec --model gpt-5.3-codex --sandbox read-only --full-auto "{task}"
+codex exec --model gpt-5.4 --sandbox read-only --full-auto "{task}"
 
 # Implementation (can write files)
-codex exec --model gpt-5.3-codex --sandbox workspace-write --full-auto "{task}"
+codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "{task}"
 ```
 
 ## Output Format

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,7 +2,7 @@
 # This file enables project-specific Codex settings
 
 # Default model configuration
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 model_reasoning_summary = "detailed"
 
@@ -10,7 +10,7 @@ model_reasoning_summary = "detailed"
 web_search = "live"
 
 # Approval policy
-approval_policy = "on-request"
+approval_policy = "never"
 
 # Feature toggles
 [features]
@@ -20,3 +20,6 @@ skills = true
 [[skills.config]]
 enabled = true
 path = ".codex/skills/context-loader"
+
+# Response style
+verbosity = "medium"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Agent tool:
 | **gemini-explore** | Opus 4.6 | 200K + Gemini 1M | Codebase analysis, research, multimodal |
 | **codex-debugger** | Opus 4.6 | 200K + Codex | Error analysis, debugging |
 | **Explore** | Opus 4.6 | 200K | Fast codebase search and exploration |
-| **Codex CLI** | gpt-5.3-codex | — | Planning, design, complex code |
+| **Codex CLI** | gpt-5.4 | — | Planning, design, complex code |
 | **Gemini CLI** | gemini-3-pro | 1M | Large-scale analysis, Google Search, multimodal |
 | **Agent Teams** | Opus 4.6 | 200K each | Parallel work with inter-agent communication |
 
@@ -146,6 +146,8 @@ Task received
 ```
 
 - Codex rules: @.claude/rules/codex-delegation.md
+- Codex-first default: delegate non-trivial development tasks to Codex via `general-purpose` unless the edit is tiny and obvious.
+- Codex handoff templates: @.claude/docs/CODEX_HANDOFF_PLAYBOOK.md
 - Gemini rules: @.claude/rules/gemini-delegation.md
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Claude Code (Orchestrator, 200K) ─┬─ Codex CLI (Planning & Complex Code)
 
 ## Quick Start
 
-既存プロジェクトのルートで実行:
+既存プロジェクトのルートで実行（事前に Codex/Gemini の起動・ログイン確認）:
 
 ```bash
-git clone --depth 1 https://github.com/DeL-TaiseiOzaki/claude-code-orchestra.git .starter && cp -r .starter/.claude .starter/.codex .starter/.gemini .starter/CLAUDE.md . && rm -rf .starter && claude
+codex --version && codex login && gemini --version && gemini login && git clone --depth 1 https://github.com/DeL-TaiseiOzaki/claude-code-orchestra.git .starter && cp -r .starter/.claude .starter/.codex .starter/.gemini .starter/CLAUDE.md . && rm -rf .starter && claude
 ```
 
 ## Prerequisites
@@ -136,6 +136,12 @@ gemini login
     ├── GEMINI.md
     └── settings.json
 ```
+
+### Codex連携を安定化するための運用
+
+- `@.claude/docs/CODEX_HANDOFF_PLAYBOOK.md` のテンプレートで Codex への依頼を統一
+- `.claude/rules/codex-delegation.md` で「Codex優先で渡す」方針と例外条件を明確化
+- `.codex/config.toml` は `approval_policy = "never"` を採用し、非対話フローでも止まりにくくする
 
 ## Workflow
 


### PR DESCRIPTION
### Motivation

- Standardize the Codex CLI integration to a newer model and make prompt/hand-off behavior more predictable across agents and skills.
- Provide a concise, enforceable playbook so Claude and subagents produce consistent, actionable Codex prompts and outputs.
- Reduce friction for non-interactive Codex runs by adjusting Codex CLI default config and improving quickstart/operational notes.

### Description

- Replaced occurrences of `gpt-5.3-codex` with `gpt-5.4` across hooks, skills, docs, AGENTS.md, and other guidance files to unify the Codex model used by the system.
- Added a new `.claude/docs/CODEX_HANDOFF_PLAYBOOK.md` detailing delegation decision matrix, prompt contract, templates for `read-only` and `workspace-write` calls, and failure/recovery guidance.
- Updated `.codex/config.toml` to set `model = "gpt-5.4"`, changed `approval_policy` to `"never"`, and added a `verbosity = "medium"` response style key.
- Adjusted delegation rules and guidance (e.g., `.claude/rules/codex-delegation.md`, various `SKILL.md` files, `CLAUDE.md`, `README.md`) to adopt a Codex-first handoff pattern, update templates, and include operational login/check steps for Codex/Gemini.
- Updated logging fallback/default for Codex in `log-cli-tools.py` to use `gpt-5.4` when a model cannot be extracted from a command.

### Testing

- No automated tests were run for this change because the PR contains documentation and configuration updates only; recommend running project linters and `poe test`/`poe lint` as a follow-up validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad1079df4083309ef7ff332f6ae85f)