### PR TITLE
Drop deprecated --full-auto and env-var-ize Codex/Gemini model names

### DIFF
--- a/.claude/agents/codex-debugger.md
+++ b/.claude/agents/codex-debugger.md
@@ -30,7 +30,7 @@ Before calling Codex, gather relevant context:
 ### Step 2: Call Codex CLI
 
 ```bash
-codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write "
 Analyze this error and provide root cause + fix:
 
 ## Error Output

--- a/.claude/agents/gemini-explore.md
+++ b/.claude/agents/gemini-explore.md
@@ -27,12 +27,22 @@ gemini -p "Analyze: components, relationships, data flow @/path/to/diagram.png" 
 
 ## Supported File Types (Multimodal)
 
+Officially supported by the Gemini Files API:
+
 | Category | Extensions |
 |----------|-----------|
 | PDF | `.pdf` |
-| Video | `.mp4`, `.mov`, `.avi`, `.mkv`, `.webm` |
-| Audio | `.mp3`, `.wav`, `.m4a`, `.flac`, `.ogg` |
-| Image (detailed analysis) | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg` |
+| Video | `.mp4`, `.mov` |
+| Audio | `.mp3`, `.wav`, `.m4a` |
+| Image (detailed analysis) | `.png`, `.jpg`, `.jpeg` |
+
+Best-effort (depends on the model's mime support):
+
+| Category | Extensions |
+|----------|-----------|
+| Video | `.avi`, `.mkv`, `.webm` |
+| Audio | `.flac`, `.ogg` |
+| Image | `.gif`, `.webp`, `.svg` |
 
 > Screenshots can be read by Claude's Read tool directly.
 > Use Gemini only for diagrams, charts, or complex image analysis.

--- a/.claude/agents/general-purpose.md
+++ b/.claude/agents/general-purpose.md
@@ -46,10 +46,10 @@ When planning, design decisions, debugging, or complex implementation is needed:
 
 ```bash
 # Analysis (read-only)
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "{question}" 2>/dev/null
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "{question}" 2>/dev/null
 
 # Implementation work (can write files)
-codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "{task}" 2>/dev/null
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write "{task}" 2>/dev/null
 ```
 
 **When to call Codex:**

--- a/.claude/docs/CODEX_HANDOFF_PLAYBOOK.md
+++ b/.claude/docs/CODEX_HANDOFF_PLAYBOOK.md
@@ -39,7 +39,7 @@ Every Codex prompt should include:
 ### A. Planning / Design (read-only)
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Create an implementation plan for {feature}.
 Constraints:
 - Keep existing architecture unless explicitly justified.
@@ -61,7 +61,7 @@ Output format:
 ### B. Complex Implementation (workspace-write)
 
 ```bash
-codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write "
 Objective: Implement {feature/fix}.
 Constraints:
 - Follow project lint/type/test rules.

--- a/.claude/hooks/agent-router.py
+++ b/.claude/hooks/agent-router.py
@@ -15,14 +15,22 @@ import sys
 
 # Multimodal file extensions that MUST be processed by Gemini
 MULTIMODAL_EXTENSIONS = [
+    # Officially supported (Gemini Files API)
     # PDF
     ".pdf",
     # Video
-    ".mp4", ".mov", ".avi", ".mkv", ".webm",
+    ".mp4", ".mov",
     # Audio
-    ".mp3", ".wav", ".m4a", ".flac", ".ogg",
+    ".mp3", ".wav", ".m4a",
     # Image (for detailed analysis — screenshots can be read by Claude directly)
-    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
+    ".png", ".jpg", ".jpeg",
+    # Best-effort, depends on model mime support
+    # Video
+    ".avi", ".mkv", ".webm",
+    # Audio
+    ".flac", ".ogg",
+    # Image
+    ".gif", ".webp", ".svg",
 ]
 
 # Pattern to detect file paths with multimodal extensions
@@ -168,7 +176,7 @@ def main():
                     "additionalContext": (
                         f"[Agent Routing] Detected '{trigger}' — this task may benefit from "
                         "Codex CLI for planning, design, or complex implementation. Consider: "
-                        "`codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+                        "`codex exec --model \"${CODEX_MODEL:-gpt-5.4}\" --sandbox read-only "
                         '"{task description}"` for design decisions, planning, debugging, '
                         "or complex analysis."
                     )

--- a/.claude/hooks/check-codex-before-write.py
+++ b/.claude/hooks/check-codex-before-write.py
@@ -127,7 +127,7 @@ def main():
                         "**Recommended**: Use Task tool with subagent_type='general-purpose' "
                         "to preserve main context. "
                         "(Direct call OK for quick questions: "
-                        "`codex exec --model gpt-5.4 --sandbox read-only --full-auto '...'`)"
+                        "`codex exec --model \"${CODEX_MODEL:-gpt-5.4}\" --sandbox read-only '...'`)"
                     )
                 }
             }

--- a/.claude/hooks/log-cli-tools.py
+++ b/.claude/hooks/log-cli-tools.py
@@ -23,8 +23,6 @@ def extract_codex_prompt(command: str) -> str | None:
     """Extract prompt from codex exec command."""
     # Pattern: codex exec ... "prompt" or codex exec ... 'prompt'
     patterns = [
-        r'codex\s+exec\s+.*?--full-auto\s+"([^"]+)"',
-        r"codex\s+exec\s+.*?--full-auto\s+'([^']+)'",
         r'codex\s+exec\s+.*?"([^"]+)"\s*2>/dev/null',
         r"codex\s+exec\s+.*?'([^']+)'\s*2>/dev/null",
     ]

--- a/.claude/rules/codex-delegation.md
+++ b/.claude/rules/codex-delegation.md
@@ -54,7 +54,7 @@ Task tool parameters:
 - prompt: |
     Consult Codex about: {topic}
 
-    codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+    codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
     Objective: {single-sentence objective}
     Constraints:
     - {constraint 1}
@@ -76,13 +76,13 @@ Task tool parameters:
 ### Direct Call (Short questions only)
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "Objective: {brief question}" 2>/dev/null
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "Objective: {brief question}" 2>/dev/null
 ```
 
 ### Having Codex Implement Code
 
 ```bash
-codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write "
 Objective: Implement {detailed implementation task}
 Constraints:
 - Follow existing project conventions
@@ -114,12 +114,16 @@ The `openai/codex-plugin-cc` plugin provides structured Codex workflows directly
 
 | Use Case | Recommended Method | Why |
 |----------|-------------------|-----|
+| Plugin setup | `/codex:setup` | Toggle features (`--enable-review-gate` / `--disable-review-gate`) |
 | Code review | `/codex:review` | Structured review with background support |
+| Synchronous review | `/codex:review --wait` | Block until review finishes |
 | Adversarial/design review | `/codex:adversarial-review` | Steerable challenge review |
 | Task delegation | `/codex:rescue` | Background jobs with status tracking |
 | Job management | `/codex:status`, `/codex:result`, `/codex:cancel` | Built-in job lifecycle |
 | Planning & design | `codex exec --sandbox read-only` | Ad-hoc queries with prompt control |
 | Complex implementation | `codex exec --sandbox workspace-write` | Full sandbox control |
+
+> Plugin source: https://github.com/openai/codex-plugin-cc
 
 ### Plugin Commands
 

--- a/.claude/rules/dev-environment.md
+++ b/.claude/rules/dev-environment.md
@@ -74,6 +74,10 @@ quote-style = "double"
 
 ## Type Checking: ty
 
+> Note: `ty` is currently in beta (0.0.x); the API and behavior are unstable. See https://docs.astral.sh/ty/ for status.
+>
+> Install: `uv tool install ty` (global) or `uv add --dev ty` (project dev dep).
+
 ```bash
 # Run type check
 uv run ty check src/

--- a/.claude/rules/gemini-delegation.md
+++ b/.claude/rules/gemini-delegation.md
@@ -33,12 +33,30 @@
 
 ## Supported File Extensions (Multimodal)
 
+Officially supported by the Gemini Files API / inline upload (per https://ai.google.dev/gemini-api/docs/files):
+
 | Category | Extensions |
 |----------|--------|
 | PDF | `.pdf` |
-| Video | `.mp4`, `.mov`, `.avi`, `.mkv`, `.webm` |
-| Audio | `.mp3`, `.wav`, `.m4a`, `.flac`, `.ogg` |
-| Image (detailed analysis) | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg` |
+| Video | `.mp4`, `.mov` |
+| Audio | `.mp3`, `.wav`, `.m4a` |
+| Image | `.png`, `.jpg`, `.jpeg` |
+
+Best-effort (depends on the selected model's mime support; may fail or degrade silently):
+
+| Category | Extensions |
+|----------|--------|
+| Video | `.avi`, `.mkv`, `.webm` |
+| Audio | `.flac`, `.ogg` |
+| Image | `.gif`, `.webp`, `.svg` |
+
+## Model Selection
+
+Override the default model via the `--model` flag (e.g. `--model gemini-3-pro`) or the `GEMINI_MODEL` environment variable. The CLI default is the Gemini 2.5 Pro family. See https://geminicli.com/docs/cli/model/ for the full list.
+
+```bash
+gemini --model "${GEMINI_MODEL:-gemini-3-pro}" -p "..." 2>/dev/null
+```
 
 ## How to Use
 

--- a/.claude/skills/add-feature/SKILL.md
+++ b/.claude/skills/add-feature/SKILL.md
@@ -109,7 +109,7 @@ Task tool:
 Consult Codex for scope analysis and impact assessment:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Analyze the scope and impact of adding this feature to the existing codebase.
 Context:
 - Feature: {feature description}
@@ -186,7 +186,7 @@ This brief is passed to Phase 2 for design.
 Consult Codex to design how the feature fits into the existing codebase:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Design the architecture for adding this feature to the existing codebase.
 Context:
 - Feature Brief: {feature brief from Phase 1}
@@ -212,7 +212,7 @@ Output format:
 Consult Codex to create a step-by-step implementation plan:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Create a step-by-step implementation plan for this feature.
 Context:
 - Feature Brief: {feature brief from Phase 1}
@@ -237,7 +237,7 @@ Output format:
 Consult Codex to validate the plan for completeness and correctness:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Validate this implementation plan for completeness, correctness, and risk.
 Context:
 - Feature Brief: {feature brief}
@@ -335,7 +335,7 @@ Shall we proceed with this plan?
 For simple features, Codex implements directly:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write "
 Objective: Implement this feature following the approved plan.
 Context:
 - Feature Brief: {feature brief}

--- a/.claude/skills/codex-system/SKILL.md
+++ b/.claude/skills/codex-system/SKILL.md
@@ -65,7 +65,7 @@ Task tool parameters:
 - prompt: |
     Consult Codex about: {topic}
 
-    codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+    codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
     {question for Codex}
     " 2>/dev/null
 
@@ -75,13 +75,13 @@ Task tool parameters:
 ### Direct Call (responses up to ~50 lines)
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "Brief question" 2>/dev/null
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "Brief question" 2>/dev/null
 ```
 
 ### Having Codex Implement Code
 
 ```bash
-codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write "
 Implement: {task description}
 Requirements: {requirements}
 Files: {file paths}
@@ -100,7 +100,7 @@ Files: {file paths}
 ### Implementation Planning
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Create an implementation plan for: {feature}
 
 Context: {relevant architecture/code}
@@ -116,7 +116,7 @@ Provide:
 ### Design Review
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Review this design approach for: {feature}
 
 Context: {relevant code or architecture}
@@ -132,7 +132,7 @@ Evaluate:
 ### Debug Analysis
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Debug this issue:
 
 Error: {error message}

--- a/.claude/skills/codex-system/references/code-review-task.md
+++ b/.claude/skills/codex-system/references/code-review-task.md
@@ -68,7 +68,7 @@ Well-implemented points
 ## Example Invocation
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Review this code change:
 
 ## Changes

--- a/.claude/skills/codex-system/references/delegation-patterns.md
+++ b/.claude/skills/codex-system/references/delegation-patterns.md
@@ -42,7 +42,6 @@ codex exec \
   --model gpt-5-codex \
   --config model_reasoning_effort="high" \
   --sandbox read-only \
-  --full-auto \
   "Review the architecture of src/auth/ module. Focus on:
    1. Single Responsibility adherence
    2. Dependency direction (should flow inward)
@@ -60,7 +59,6 @@ codex exec \
   --model gpt-5-codex \
   --config model_reasoning_effort="high" \
   --sandbox read-only \
-  --full-auto \
   "This bug has resisted 2 fix attempts:
 
    Symptom: Race condition in user session handling
@@ -82,7 +80,6 @@ codex exec \
   --model gpt-5-codex \
   --config model_reasoning_effort="xhigh" \
   --sandbox read-only \
-  --full-auto \
   "Optimize the algorithm in src/data/aggregator.py:
 
    Current: O(n²) nested loops for data aggregation
@@ -106,7 +103,6 @@ codex exec \
   --model gpt-5-codex \
   --config model_reasoning_effort="xhigh" \
   --sandbox read-only \
-  --full-auto \
   "Security audit of src/api/auth.py:
 
    Check for:

--- a/.claude/skills/codex-system/references/refactoring-task.md
+++ b/.claude/skills/codex-system/references/refactoring-task.md
@@ -62,7 +62,7 @@ Provide:
 ## Example Invocation
 
 ```bash
-codex exec --model gpt-5.4 --sandbox workspace-write --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write "
 Refactor this code for simplicity:
 
 ## Target Code

--- a/.claude/skills/spike/SKILL.md
+++ b/.claude/skills/spike/SKILL.md
@@ -93,7 +93,7 @@ Ask the user to provide:
 Consult Codex to decompose the spike question into a structured investigation plan:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Decompose this spike question into a structured investigation plan.
 Context:
 - Spike question: {question/hypothesis from user}
@@ -259,7 +259,7 @@ Spawn two teammates:
 
    ### 1. Technical Feasibility Assessment
    For each sub-question, consult Codex:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Assess technical feasibility of {sub-question}.
    Context:
    - Spike question: {main question}
@@ -280,7 +280,7 @@ Spawn two teammates:
 
    ### 2. Architecture Compatibility Analysis
    Consult Codex to evaluate fit with existing architecture:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Evaluate how {proposed approach} fits with the existing architecture.
    Context:
    - Proposed approach: {description}
@@ -299,7 +299,7 @@ Spawn two teammates:
 
    ### 3. Risk and Trade-off Analysis
    Consult Codex to evaluate risks:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Identify and evaluate risks of adopting {proposed approach}.
    Context:
    - Proposed approach: {description}
@@ -319,7 +319,7 @@ Spawn two teammates:
 
    ### 4. Prototype Validation (PROTOTYPE mode only)
    If the investigation mode is PROTOTYPE, build a minimal throwaway prototype:
-   codex exec --model gpt-5.4 --sandbox workspace-write --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox workspace-write '
    Objective: Build a minimal prototype to validate {specific technical question}.
    Context:
    - Question to validate: {what the prototype tests}
@@ -409,7 +409,7 @@ Read outputs from Phase 2:
 Consult Codex to synthesize all findings into a go/no-go recommendation:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Synthesize spike investigation findings and produce a go/no-go recommendation.
 Context:
 - Spike question: {original question}

--- a/.claude/skills/start-feature/SKILL.md
+++ b/.claude/skills/start-feature/SKILL.md
@@ -190,7 +190,7 @@ Spawn two teammates:
    4. Identify risks and mitigation strategies
 
    How to consult Codex:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto "{question}" 2>/dev/null
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "{question}" 2>/dev/null
 
    Update .claude/docs/DESIGN.md with architecture decisions.
 

--- a/.claude/skills/team-review/SKILL.md
+++ b/.claude/skills/team-review/SKILL.md
@@ -123,7 +123,7 @@ Spawn reviewers:
    - Library constraint violations (.claude/docs/libraries/)
 
    Use Codex CLI for deep analysis of complex logic:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto "{question}" 2>/dev/null
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "{question}" 2>/dev/null
 
    Changed files: {list}
 

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -98,7 +98,7 @@ Task tool:
 Consult Codex for initial hypothesis generation before creating the Bug Report:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Analyze this error and generate initial hypotheses for root cause.
 Context:
 - Error: {error message / stack trace}
@@ -202,7 +202,7 @@ Spawn two teammates:
 
    ### 1. Execution Flow Tracing
    For complex control flow, consult Codex:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Trace the execution flow from {entry point} to {error location}.
    Context:
    - Entry point: {file:function}
@@ -220,7 +220,7 @@ Spawn two teammates:
 
    ### 2. Hypothesis Evaluation
    For each hypothesis, consult Codex to evaluate evidence:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Evaluate hypothesis \"{hypothesis}\" against collected evidence.
    Context:
    - Hypothesis: {description}
@@ -238,7 +238,7 @@ Spawn two teammates:
 
    ### 3. Fix Approach Design
    Consult Codex for trade-off analysis of fix alternatives:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Design and compare fix approaches for root cause: {root cause description}.
    Context:
    - Root cause: {description}
@@ -258,7 +258,7 @@ Spawn two teammates:
 
    ### 4. Fix Correctness Verification
    Before finalizing, consult Codex to verify the proposed fix:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Verify that the proposed fix correctly resolves the root cause.
    Context:
    - Root cause: {description}
@@ -348,7 +348,7 @@ Spawn two teammates:
 
    ### Regression Risk Reasoning
    Consult Codex to evaluate what could break if the proposed change is applied:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Evaluate regression risk if {proposed change} is applied to {file:line}.
    Context:
    - Current behavior: {description}
@@ -368,7 +368,7 @@ Spawn two teammates:
 
    ### Fix Safety Analysis
    Consult Codex to verify the proposed fix does not introduce new issues:
-   codex exec --model gpt-5.4 --sandbox read-only --full-auto '
+   codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only '
    Objective: Analyze whether the proposed fix introduces new issues or side effects.
    Context:
    - Root cause: {from Root Cause Analyst}
@@ -459,7 +459,7 @@ Read outputs from Phase 2:
 Before presenting to the user, validate the fix plan with Codex:
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only --full-auto "
+codex exec --model "${CODEX_MODEL:-gpt-5.4}" --sandbox read-only "
 Objective: Validate this fix plan for completeness and correctness.
 Context:
 - Root cause: {from Root Cause Analyst}


### PR DESCRIPTION
## Summary
- Remove deprecated `--full-auto` from all `codex exec` invocations across docs/skills/hooks; use explicit `--sandbox` per the official Codex CLI reference.
- Replace hardcoded `gpt-5.4` with `${CODEX_MODEL:-gpt-5.4}` (and `${GEMINI_MODEL:-gemini-3-pro}` where applicable) so model versions can be overridden via env vars without editing every file.
- Tighten the Gemini extension table: officially supported (`.pdf`, `.mp4`, `.mov`, `.mp3`, `.wav`, `.m4a`, `.png`, `.jpg`, `.jpeg`) vs. best-effort (depends on model mime support); add model override note linking to https://geminicli.com/docs/cli/model/ .
- Add Codex plugin entries to `codex-delegation.md` (`/codex:setup` toggle flags, `/codex:review --wait` synchronous variant).
- Add `ty` beta (0.0.x) notice with install instructions to `dev-environment.md`.

## Verification
- `grep -rn '\-\-full-auto' . --include='*.md' --include='*.py'` → 0 matches
- Remaining naked `gpt-5.4` matches are intentional: 3× `/codex:rescue --model gpt-5.4-mini` plugin examples (model-specific) and 1× Python fallback in `log-cli-tools.py:100` (shell expansion not applicable).

## Test plan
- [ ] Confirm Codex CLI invocations still succeed with the new flag layout
- [ ] Confirm `${CODEX_MODEL}` / `${GEMINI_MODEL}` overrides flow through hooks and skill commands
- [ ] Spot-check rendered docs (`gemini-delegation.md`, `dev-environment.md`, `codex-delegation.md`)

https://claude.ai/code/session_01UYjUr1LRBH6v9J722ztCpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYjUr1LRBH6v9J722ztCpa)_