### PR TITLE
fix(install): never destroy a repo's existing native subagents and skills

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -220,6 +220,23 @@ collect_conflicts() {
         fi
     done
 
+    # Native discovery paths are project-owned until we link them: a target repo
+    # may already keep its own subagents/skills there. Anything that is not
+    # already the exact link we are about to create counts as a conflict, so it
+    # is reported and backed up instead of being destroyed by the link step.
+    local entry native_path target
+    for entry in "${NATIVE_DISCOVERY_LINKS[@]}"; do
+        native_path="${entry%%:*}"
+        target="${entry##*:}"
+        if [[ -L "${TARGET_ROOT}/${native_path}" ]] \
+            && [[ "$(readlink -- "${TARGET_ROOT}/${native_path}")" == "${target}" ]]; then
+            continue
+        fi
+        if [[ -e "${TARGET_ROOT}/${native_path}" || -L "${TARGET_ROOT}/${native_path}" ]]; then
+            CONFLICTS+=("${native_path}")
+        fi
+    done
+
     if [[ ${#CONFLICTS[@]} -eq 0 ]]; then
         return 0
     fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -618,7 +618,7 @@ repair_claude_entrypoint() {
 link_native_discovery_dirs() {
     header "Linking Native Discovery Directories"
 
-    local entry native_path target link
+    local entry native_path target link backup_root=""
     for entry in "${NATIVE_DISCOVERY_LINKS[@]}"; do
         native_path="${entry%%:*}"
         target="${entry##*:}"
@@ -627,11 +627,25 @@ link_native_discovery_dirs() {
             info "Verified ${native_path} -> ${target}"
             continue
         fi
-        rm -rf -- "${link}"
+        # Real content here is project-owned (a repo that kept its own
+        # subagents/skills natively, or a link corrupted into a file). Preserve
+        # it before replacing, so the link step can never destroy user data.
+        if [[ -e "${link}" || -L "${link}" ]]; then
+            if [[ -z "${backup_root}" ]]; then
+                backup_root="${PROJECT_ROOT}/.orchestra-backup-native-discovery-$(date +%Y%m%d%H%M%S)-$$"
+            fi
+            mkdir -p "${backup_root}/$(dirname -- "${native_path}")"
+            cp -a -- "${link}" "${backup_root}/${native_path}"
+            rm -rf -- "${link}"
+        fi
         mkdir -p "$(dirname -- "${link}")"
         ln -s "${target}" "${link}"
         UPDATED_FILES+=("${native_path} -> ${target}")
     done
+
+    if [[ -n "${backup_root}" ]]; then
+        warn "Existing native discovery content was backed up: ${backup_root}"
+    fi
 }
 
 # =============================================================================

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -191,6 +191,93 @@ def test_force_install_backs_up_conflicts_before_replacing_them(
     assert not (target / ".agents/rules/custom.md").exists()
 
 
+def test_install_refuses_to_destroy_existing_native_subagents_and_skills(
+    tmp_path: Path,
+) -> None:
+    """A repo that already uses Claude Code natively keeps its own subagents and
+    skills in .claude/. Linking those paths must never silently delete them."""
+    target = tmp_path / "project"
+    init_git_repo(target)
+    existing_agent = target / ".claude/agents/my-agent.md"
+    existing_agent.parent.mkdir(parents=True)
+    existing_agent.write_text("user's own subagent\n", encoding="utf-8")
+    existing_skill = target / ".claude/skills/my-skill/SKILL.md"
+    existing_skill.parent.mkdir(parents=True)
+    existing_skill.write_text("user's own skill\n", encoding="utf-8")
+
+    result = run_install(target)
+
+    assert result.returncode == 2
+    assert "--force" in result.stderr
+    assert existing_agent.read_text(encoding="utf-8") == "user's own subagent\n"
+    assert existing_skill.read_text(encoding="utf-8") == "user's own skill\n"
+    assert not (target / "AGENTS.md").exists()
+
+
+def test_force_install_backs_up_existing_native_subagents_and_skills(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "project"
+    init_git_repo(target)
+    existing_agent = target / ".claude/agents/my-agent.md"
+    existing_agent.parent.mkdir(parents=True)
+    existing_agent.write_text("user's own subagent\n", encoding="utf-8")
+
+    result = run_install(target, "--force")
+
+    assert result.returncode == 0, result.stderr
+    backups = list(target.glob(".orchestra-backup-*"))
+    assert len(backups) == 1
+    assert (backups[0] / ".claude/agents/my-agent.md").read_text(
+        encoding="utf-8"
+    ) == "user's own subagent\n"
+    assert (target / ".claude/agents").is_symlink()
+    assert (target / ".claude/agents").readlink().as_posix() == "../.agents/agents"
+
+
+def test_existing_correct_discovery_link_is_not_treated_as_a_conflict(
+    tmp_path: Path,
+) -> None:
+    """A path that is already exactly the link we would create carries no user
+    data, so it must not abort the install the way real content does."""
+    target = tmp_path / "project"
+    init_git_repo(target)
+    (target / ".claude").mkdir()
+    (target / ".claude/agents").symlink_to("../.agents/agents")
+
+    result = run_install(target)
+
+    assert result.returncode == 0, result.stderr
+    assert (target / ".claude/agents").is_symlink()
+    assert (target / ".claude/agents").readlink().as_posix() == "../.agents/agents"
+    assert (target / ".claude/agents/general-purpose-opus.md").is_file()
+
+
+def test_update_backs_up_native_discovery_content_instead_of_deleting_it(
+    tmp_path: Path,
+) -> None:
+    template = build_template_repo(tmp_path)
+    target = tmp_path / "project"
+    init_git_repo(target)
+    assert run_install(target, script=template / "scripts/install.sh").returncode == 0
+
+    link = target / ".claude/agents"
+    link.unlink()
+    link.mkdir()
+    (link / "downstream-agent.md").write_text("downstream agent\n", encoding="utf-8")
+
+    update_result = run_update(target, template)
+
+    assert update_result.returncode == 0, update_result.stderr
+    assert link.is_symlink()
+    assert link.readlink().as_posix() == "../.agents/agents"
+    backups = list(target.glob(".orchestra-backup-native-discovery-*"))
+    assert len(backups) == 1
+    assert (backups[0] / ".claude/agents/downstream-agent.md").read_text(
+        encoding="utf-8"
+    ) == "downstream agent\n"
+
+
 def test_install_preserves_existing_settings_and_writes_merge_candidate(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 概要 / Summary

**#80 で入れたリグレッションの修正です。** 既存の Claude Code 利用リポジトリに `install.sh` を実行すると、ユーザー自身のサブエージェント／スキルが**警告もバックアップもなく削除**され、しかも成功終了（exit 0）していました。

## 原因 / Root cause

#80 で `.claude/agents` と `.claude/skills` を `LEGACY_NATIVE_PATHS` から外した際、同リストが `collect_conflicts()` の走査対象でもあったため、**衝突検出からも同時に外れました**。一方で新設の `link_native_discovery_dirs()` は無条件に `rm -rf` します。結果、既存の実ディレクトリが黙って破壊されました。

これは 2026-07-16 の設計判断（`TEMPLATE_DESIGN_LOG.md`）に明記された installer の根幹不変条件に違反します：

> *A template must not silently overwrite project-owned Claude/Codex configuration.*

### 実測での再現（修正前）

`.claude/agents/my-precious-agent.md` と `.claude/skills/my-deploy/SKILL.md` を持つリポジトリに対して:

| | 変更前 (`b921ae7`) | #80 適用後 (`5350fcc`) |
|---|---|---|
| 終了コード | **2**（中断） | **0**（成功扱い） |
| ユーザーのファイル | 保持 | **削除** |
| バックアップ | ―（変更前に中断） | **なし** |
| git 復旧 | 不要 | commit 済みなら可／**未追跡なら消失** |

## 修正 / Fix

- **`scripts/install.sh`**: `collect_conflicts()` が native discovery パスを検査。**「作ろうとしている symlink と完全一致」でない限り衝突として扱う**ため、実体があれば既定で中断し、`--force` 時はバックアップされます。既に正しい symlink の場合はユーザーデータが無いので衝突扱いしません（冪等性を維持）。
- **`scripts/update.sh`**: `link_native_discovery_dirs()` が実体を `.orchestra-backup-native-discovery-*` へ退避してから置換し、警告を出します（従来の silent `rm -rf` を廃止）。
- **`tests/test_install_script.py`**: 回帰テスト4件を追加。
  - 既定で中断しユーザーデータが無傷であること
  - `--force` でバックアップされたうえでリンクが張られること
  - 既に正しい symlink なら衝突扱いしないこと
  - updater が実体をバックアップしてからリンク化すること

## 検証 / Validation

- `uv run pytest -q` → **226 passed**（rsync 非搭載環境のため、symlink 保持の rsync シムを PATH に載せて実行）
- `bash .agents/check.sh` → 8 passed, 0 failed
- `uv run ruff check tests/` → クリーン
- 再現シナリオでの end-to-end 確認:
  - 既定実行 → `EXIT=2`、`.claude/agents` `.claude/skills` の中身が両方とも無傷
  - `--force` → 2ファイルともバックアップに退避、リンク生成、`.claude/skills/context-loader/SKILL.md` がリンク経由で読める

## 補足 / Note

本修正は #80 の設計（`.agents/` を単一の実体とする発見用 symlink）自体は変更しません。その設計を、既存リポジトリのデータを壊さずに適用するためのガードを復元するものです。

---
_Generated by [Claude Code](https://claude.ai/code/session_019z5hQqQbYRzepshjZjKsYH)_