### PR TITLE
Make subagent delegation the default across the shared contract

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -14,6 +14,7 @@
 |-------------------------------|-----------------------|-----------------------------------------------|------------------------------------|
 | Root agent contract           | normative             | `AGENTS.md`                                  | Mission, routing, catalogs, execution, quality, language, ownership |
 | Tier definitions              | normative             | `.agents/rules/tiers.md`                            | 3-tier hierarchy (default/sol/fable) |
+| Delegation-first policy       | normative             | `.agents/rules/delegation.md`                       | Self-handle list, mandatory triggers, route table, subagent prompt contract |
 | CLI executor extension        | normative             | `.agents/rules/cli-execution.md`                           | Response, handoff, and verification rules |
 | Shared rules                  | normative             | `.agents/rules/`                              | Coding, testing, security, routing, and state rules |
 | Shared skills                 | normative             | `.agents/skills/`                             | Workflow and deterministic helper implementations |

--- a/.agents/rules/codex-delegation.md
+++ b/.agents/rules/codex-delegation.md
@@ -2,6 +2,10 @@
 
 **Codex CLI handles planning, design, and complex code implementation.**
 
+> Scope: this rule decides *when Codex specifically*. Whether the main agent may
+> keep a task at all is decided first by `.agents/rules/delegation.md`, whose
+> default is to delegate.
+
 > Preflight: ensure codex CLI is current (see codex-system skill).
 
 ## Two Roles of Codex

--- a/.agents/rules/delegation.md
+++ b/.agents/rules/delegation.md
@@ -1,0 +1,119 @@
+# Delegation-First Rule
+
+**The main agent's default answer to "who does this work?" is *not me*.**
+
+This rule is normative and tool-neutral. It governs *whether* to delegate and
+*to whom*. `.agents/rules/codex-delegation.md` covers the Codex-specific
+triggers and handoff contract; `.agents/rules/tiers.md` defines the tiers; this
+file is the one that decides that delegation happens at all.
+
+## Default Posture
+
+Delegate by default. Direct execution by the main agent is the **exception**,
+and every exception must be justified by the Self-Handle List below. The main
+agent's scarce resource is context and judgment, not tokens: work it performs
+itself is work whose intermediate output permanently occupies the conversation.
+
+## Self-Handle List (closed)
+
+The main agent does the work itself **only** when the whole task is one of:
+
+1. Answering from context already loaded this session — no new file reading.
+2. A single-file edit of roughly 20 lines or fewer, in a file whose exact
+   location and current contents are already known.
+3. Running a named command or gate and reporting its result:
+   `.agents/skills/_shared/verify.sh`, `.agents/skills/_shared/run_tests.py`,
+   `.agents/check.sh`, `git status` / `diff` / `commit` / `push`.
+4. Deterministic skill-bundled scripts a `SKILL.md` explicitly assigns to the
+   lead (`workspace.py`, `validate_doc.py`, `update_design.py`,
+   `append_state_block.py`, `checkpoint.py`, `collect_repo_state.py`, …).
+5. User interaction: clarifying questions, approvals, routing decisions,
+   integration of returned results, and the final Japanese report.
+
+The list is closed. "It would be faster to just do it myself" is not on it, and
+neither is "the task is small enough that delegating feels like overhead."
+
+## Mandatory Delegation Triggers
+
+Delegate as soon as **any** of these holds — do not investigate first and then
+decide:
+
+- Three or more files must be read, **or** any file must be read whose contents
+  are not already in this session's context.
+- The expected output exceeds roughly 30 lines of code or prose.
+- Locations are unknown and finding them needs a codebase-wide search sweep.
+- Current external information must be verified (docs, APIs, releases).
+- A command failed and its root cause is not already proven by evidence in hand.
+- Design, step decomposition, trade-off evaluation, or complex implementation is
+  involved.
+- Two or more independent workstreams exist in the request.
+
+## Route Selection
+
+| Work | Route |
+|------|-------|
+| Routine, well-scoped implementation with clear acceptance criteria | `general-purpose-sonnet` |
+| Ambiguous, cross-cutting, security / concurrency / data-integrity / migration-sensitive implementation | `general-purpose-opus` |
+| Codebase-wide investigation, large-context analysis, external research | `general-purpose-opus` |
+| Unknown root cause, failing tests or builds, unexpected behaviour | `codex-debugger` |
+| Architecture, planning, decomposition, complex algorithms, code review | Codex (`codex-system` skill / `.agents/skills/_shared/codex_consult.py`) |
+| Repeated failure, conflicting proposals, final review of a large change | `fable-advisor` (rare) |
+
+Escalate rather than retry: a `general-purpose-sonnet` task that comes back
+wrong or under-specified goes to `general-purpose-opus` or Codex, not back to
+the same tier with the same prompt.
+
+## Parallel by Default
+
+When two or more delegable units are independent, launch them **in a single
+message** so they run concurrently. Sequential delegation is reserved for
+genuine data dependency — when the next prompt cannot be written without the
+previous result. Typical parallel splits: investigation vs. external research,
+implementation vs. test authoring, per-module ownership, review dimensions
+(security / quality / test coverage).
+
+## Subagent Prompt Contract
+
+Every delegation carries all six, in the delegating message:
+
+1. **Objective** — one sentence, the decision the result must enable.
+2. **Scope** — what is in, what is explicitly out, what must not be touched.
+3. **Inputs** — explicit file paths, plus the rules the subagent must load.
+4. **Acceptance checks** — the exact commands that prove the work is done.
+5. **Output shape** — the sections required in the reply.
+6. **Context discipline** — "return only decision-relevant findings; write long
+   output to `.agents/docs/…` or `.agents/logs/…` and return the path."
+
+A subagent that had to guess any of the six was under-specified by the caller.
+
+## Context Discipline
+
+Long logs, large files, and full search dumps never enter the main agent's
+context. Delegate the reading, have the subagent persist the durable artifact,
+and take back the summary plus the path.
+
+## Verification Stays With the Caller
+
+Delegation transfers the work, never the accountability. Before reporting any
+delegated result as done:
+
+- run the acceptance checks from the prompt contract yourself;
+- inspect the diff (`.agents/skills/_shared/verify_delegation.py`,
+  `git diff --stat`) for out-of-scope edits, deletions, and placeholders;
+- apply the guardrails in `.agents/rules/cli-execution.md` section "Guardrails
+  (Completion Verification)" — weakened or skipped tests, swallowed exceptions,
+  and hardcoded return values are rejections, not completions.
+
+Report a delegated result as verified only when you ran the check that proves it.
+
+## Anti-Patterns
+
+- Investigating "just enough to understand it" and then delegating nothing —
+  the investigation *was* the delegable work.
+- Splitting one delegable task into a long chain of main-agent tool calls.
+- Reading a file in the main agent so the subagent prompt can quote it; pass the
+  path instead.
+- Over-delegation: one subagent per trivial edit, or a delegation whose prompt
+  takes longer to write than the edit would. Item 2 of the Self-Handle List
+  exists for exactly these.
+- Delegating a decision that is the user's to make.

--- a/.agents/skills/context-loader/SKILL.md
+++ b/.agents/skills/context-loader/SKILL.md
@@ -34,9 +34,9 @@ The JSON reports `{ok, read_order, rules, state, design, progress, libraries,
 missing, unreadable, warnings}`. `read_order` is the exact ordered list of
 repo-relative paths to read, in this order:
 
-1. the rule files in `.agents/rules/` (coding principles, dev environment,
-   language, security, testing, tiers, CLI execution, Codex delegation, and any
-   newly added rule file);
+1. the rule files in `.agents/rules/` (coding principles, delegation, dev
+   environment, language, security, testing, tiers, CLI execution, Codex
+   delegation, and any newly added rule file);
 2. `.agents/STATE.md` — the active main agent and current working blocks;
 3. `PROGRESS.md` — the rolling record of the latest five checkpoints, and the
    session-to-session continuity `/feature` reads first;
@@ -67,12 +67,35 @@ Read each path in `read_order`. Then check the rest of the report:
 Exit code 2 means `.agents/rules/` or `.agents/STATE.md` is missing entirely or
 unreadable — treat this as a hard stop, not a warning.
 
-### Step 3: Execute Task
+### Step 3: Route the Task Before Touching It
 
-With the loaded context, execute the requested task following:
+`.agents/rules/delegation.md` was just loaded, and it applies from here on: the
+default is to delegate, and working alone is the exception. Before the first
+`Read`, `Grep`, or `Edit` of the actual task, decide the route out loud:
+
+1. Does the whole task fall on the **Self-Handle List** (answer from loaded
+   context · one known file, ~20 lines or fewer · a named gate or a
+   skill-bundled lead script · user interaction)? If yes, do it directly.
+2. Otherwise name the route from the rule's table — `general-purpose-sonnet`,
+   `general-purpose-opus`, `codex-debugger`, Codex, `fable-advisor` — or the
+   skill that owns the workflow, and delegate with all six elements of the
+   Subagent Prompt Contract.
+3. Split independent units and launch them **in one message** so they run in
+   parallel.
+
+Deciding the route after investigating is the anti-pattern the rule names: the
+investigation was itself the delegable work. When both routes look defensible,
+delegate.
+
+### Step 4: Execute or Delegate the Task
+
+With the loaded context, execute the route chosen in Step 3, following:
 - Coding principles from rules
 - Design decisions from DESIGN.md
 - Library constraints from docs
+
+If the work was delegated, verification stays here: run the acceptance checks
+and inspect the diff before reporting the result as done.
 
 ## Key Rules
 
@@ -90,4 +113,6 @@ After loading context, briefly confirm in Japanese:
 - the `missing`, `unreadable`, and `warnings` arrays **quoted verbatim** from the
   JSON — not paraphrased, not summarised as "no issues";
 - `design.placeholder` and `progress.entries` as reported;
+- **the route chosen in Step 3** — the subagent, Codex, or skill that will do
+  the work, or, when handling it directly, which Self-Handle List item applies;
 - ready to execute the task.

--- a/.agents/skills/context-loader/load_context.py
+++ b/.agents/skills/context-loader/load_context.py
@@ -46,6 +46,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 # Stable prefix order; any rule file not listed here is appended alphabetically.
 PREFERRED_RULE_ORDER = [
     "coding-principles",
+    "delegation",
     "dev-environment",
     "language",
     "security",

--- a/.agents/skills/simplify/SKILL.md
+++ b/.agents/skills/simplify/SKILL.md
@@ -67,6 +67,50 @@ command with its exit code, and re-run with `--allow-no-gates` so the payload
 carries `allow_no_gates: true`. Do not edit code first and decide how to verify
 it afterwards.
 
+### Steps 1-4 Are Delegated
+
+Reading the target files, checking library behaviour, and applying the edits are
+all past the triggers in `.agents/rules/delegation.md` — an unread file, a
+codebase sweep, external lookup, more than ~30 lines of output. The lead keeps
+Step 0, Step 5, and the "is this actually simpler" judgment; everything between
+them is delegated, one delegation per scope entry, launched in parallel when the
+scopes are independent:
+
+```
+Task tool:
+  subagent_type: "general-purpose-sonnet"   # general-purpose-opus when the code carries
+                                            # security, concurrency, or data-integrity risk
+  prompt: |
+    Objective: Simplify {scope path} without changing observable behaviour.
+
+    Scope:
+    - Edit only these paths: {the same --scope entries passed in Step 0}.
+    - Refactor only. No new features, no API changes, no dependency changes.
+    - Do not modify, skip, or weaken any test.
+
+    Inputs:
+    - Read .agents/rules/coding-principles.md first.
+    - Library constraints: .agents/docs/libraries/ (check every library the target uses;
+      WebSearch only what those notes do not answer).
+    - Apply the Simplification Principles and the patterns in
+      .agents/skills/simplify/SKILL.md (early return, extract function).
+
+    Acceptance checks — run before returning:
+      bash .agents/skills/_shared/verify.sh
+
+    Output shape:
+    ## Hotspots found (file:line -> problem)
+    ## Changes applied (file:line -> what and why it reads better)
+    ## Library constraints that shaped or blocked a change
+    ## Anything deliberately left alone
+
+    Context discipline: return the summary only; do not paste diffs or file bodies.
+```
+
+The reference material below is what the delegate follows — and what the lead
+applies directly when the target is a single already-open file of roughly 20
+lines or fewer (Self-Handle List item 2).
+
 ### 1. Analyze Target Code
 
 - Read the file(s) to understand current structure

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -23,6 +23,24 @@ is *not* judgment is whether a run came out the way you expected: every test run
 in this skill goes through `.agents/skills/_shared/run_tests.py`, which turns
 "confirm failure" / "confirm success" into an exit code.
 
+## Who Does What (delegation-first)
+
+Per `.agents/rules/delegation.md`, the lead does not write the cycles by hand.
+The split is fixed:
+
+| Work | Owner |
+|------|-------|
+| Requirement clarification, test-case list, boundary values | Lead (judgment, Self-Handle List item 5) |
+| Writing the tests and the production code, cycle by cycle | `general-purpose-sonnet` |
+| Cycles with ambiguous design, cross-cutting invariants, or security / concurrency / data-integrity risk | `general-purpose-opus` |
+| A Red that is red for the wrong reason, or a Green that will not go green after one retry | `codex-debugger` |
+| Every `run_tests.py` / `verify.sh` gate and the final report | Lead — verification never delegates |
+
+Only a *single trivial cycle* on a file already open in context stays with the
+lead (Self-Handle List item 2). Two or more cycles, or a module the lead has not
+read, is delegated. Independent modules are delegated **in parallel in one
+message**; they share no test file, so nothing serializes them.
+
 ## The Red/Green Invariant
 
 ```bash
@@ -83,6 +101,52 @@ Which cases to write, and which boundary values matter, is domain reasoning —
 never delegate it to a script.
 
 ### Phase 2: Red-Green-Refactor
+
+#### Step 0: Hand the Cycles Off
+
+Delegate the Red-Green-Refactor loop with the six-element prompt contract from
+`.agents/rules/delegation.md`. One delegation per module, all launched together:
+
+```
+Task tool:
+  subagent_type: "general-purpose-sonnet"   # or general-purpose-opus, see the table above
+  prompt: |
+    Objective: Implement {module} by strict TDD, one test case at a time.
+
+    Scope:
+    - Write only tests/test_{module}.py and src/{module}.py. Touch nothing else.
+    - Do not modify existing tests, and never skip, delete, or weaken an assertion.
+
+    Inputs:
+    - Test cases to implement, in this order: {the Phase 1 list}
+    - Read .agents/rules/coding-principles.md and .agents/rules/testing.md first.
+    - Existing conventions to follow: {paths of comparable modules}
+
+    Acceptance checks — run these yourself, per cycle, and never skip Red:
+      python3 .agents/skills/_shared/run_tests.py \
+        --target tests/test_{module}.py --expect fail --label red-{n}
+      python3 .agents/skills/_shared/run_tests.py \
+        --target tests/test_{module}.py --expect pass --label green-{n}
+    A Red that exits 2 with observed=passed/collection_error/no_tests_collected
+    is not a Red: fix the test, not the production code, and re-run.
+
+    Output shape:
+    ## Cycles completed (case -> red label -> green label)
+    ## Files changed
+    ## Deviations from the requested test cases, and why
+    ## Anything that did not go green
+
+    Context discipline: return this summary only; the run logs stay in
+    .agents/logs/ and are referenced by label, not pasted.
+```
+
+Then verify rather than trust: re-run `run_tests.py --expect pass` yourself and
+read the diff. A reported cycle with no matching `run_tests.py` exit `0` did not
+happen. If a cycle came back unfinished, escalate it (`general-purpose-opus` or
+`codex-debugger`) instead of re-sending the same prompt to the same tier.
+
+The steps below are the contract the delegate follows — and what the lead runs
+directly in the single-trivial-cycle case.
 
 #### Step 1: Write First Test (Red)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,11 @@ live in `.agents/rules/tiers.md`.
 
 ## Routing Policy
 
-- Minor fixes and short questions → main agent directly.
+**Delegate by default; direct execution is the exception.** The main agent works
+alone only on the closed Self-Handle List in `.agents/rules/delegation.md`:
+answers from already-loaded context, a single known file edited by ~20 lines or
+fewer, named gates and skill-bundled lead scripts, and user-facing interaction.
+
 - Routine, clear implementation → `general-purpose-sonnet`.
 - Ambiguous, security-, concurrency-, data-integrity-, or migration-sensitive
   implementation → `general-purpose-opus`, consulting Codex as needed.
@@ -47,10 +51,15 @@ live in `.agents/rules/tiers.md`.
 - Unknown root cause → `codex-debugger`.
 - Repeatedly stuck or high-stakes arbitration → `fable-advisor`.
 
-Delegate when output is likely to exceed 10 lines, three or more files require
-substantial reading, or current external information must be verified. Detailed
-Codex triggers and handoff requirements live in
-`.agents/rules/codex-delegation.md`.
+Delegate as soon as any trigger fires — do not investigate first and then
+decide: a third file must be read, an unread file must be opened, output is
+likely to exceed ~30 lines, locations are unknown, external information must be
+verified, or a root cause is unproven. Independent units are delegated in
+parallel in one message. Delegation moves the work, never the accountability:
+run the acceptance checks and inspect the diff before reporting done. The full
+policy, route table, and subagent prompt contract live in
+`.agents/rules/delegation.md`; Codex-specific triggers and handoff requirements
+in `.agents/rules/codex-delegation.md`.
 
 ## Skill Catalog
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Use the routing policy and execution patterns in root `AGENTS.md`.
 Product-specific delegation mechanics remain in `.agents/rules/` and the
 corresponding canonical agent or skill definitions.
 
+The posture is **delegation-first**: `.agents/rules/delegation.md` makes direct
+execution by the main agent the exception, limited to a closed Self-Handle List,
+and names the triggers, route table, and subagent prompt contract that every
+skill follows. Delegating moves the work, not the accountability — the caller
+still runs the acceptance checks and inspects the diff.
+
 ## Directory Structure
 
 `.agents/` owns shared policy, runtime content, project context, and state.
@@ -190,7 +196,7 @@ point directly to canonical capabilities under `.agents/`.
 │   ├── skills/                  # Shared workflow skills and deterministic helpers
 │   │   └── _shared/             # Bundled runtime: helpers every skill may depend on
 │   ├── hooks/                   # Claude hook implementations (canonical)
-│   ├── rules/                   # Shared policy, tiers, CLI, coding, testing, and security rules
+│   ├── rules/                   # Shared policy: delegation, tiers, CLI, coding, testing, security
 │   ├── docs/                    # Design, handoff, research, review, and library documents
 │   ├── logs/                    # Runtime logs (git-ignored)
 │   ├── checkpoints/             # Session checkpoints (git-ignored)


### PR DESCRIPTION
## Problem

The main agent kept absorbing work the agent topology exists to distribute. Nothing in the shared contract made delegation the *default* posture — `AGENTS.md` listed routes but framed delegation as a threshold ("output likely to exceed 10 lines"), and the implementation skills (`tdd`, `simplify`) described every step as lead-executed, so the lead naturally did the work itself.

## Changes

- **New normative rule `.agents/rules/delegation.md`** — delegation-first policy: a *closed* Self-Handle List (answer from loaded context · one known file, ~20 lines or fewer · named gates and skill-bundled lead scripts · user interaction), mandatory delegation triggers, a route-selection table, parallel-by-default, a six-element subagent prompt contract, context discipline, caller-side verification, and anti-patterns (including over-delegation).
- **`AGENTS.md` Routing Policy** — now leads with "delegate by default; direct execution is the exception", raises the output threshold to ~30 lines, adds "do not investigate first and then decide", parallel fan-out, and the accountability rule. Still 135/140 lines.
- **`context-loader`** — `delegation` added to `PREFERRED_RULE_ORDER` so the rule loads early, plus a new **Step 3: Route the Task Before Touching It** that requires an explicit routing decision before the first `Read`/`Grep`/`Edit`, and reports the chosen route in the skill's output.
- **`tdd`** — a "Who Does What" ownership table and a new Phase 2 Step 0 that hands the Red-Green-Refactor cycles to `general-purpose-sonnet` (or `general-purpose-opus` / `codex-debugger`) with a full prompt; the lead keeps test-case design, every gate, and verification.
- **`simplify`** — Steps 1-4 (read, library check, plan, edit) are delegated per scope entry with a concrete prompt; the lead keeps the Step 0 baseline, the Step 5 gate comparison, and the "is this actually simpler" judgment.
- **Registration** — new row in `.agents/INDEX.md`, scope note in `codex-delegation.md` pointing at the new rule, and a delegation-first paragraph in `README.md`.

## Verification

- `bash .agents/check.sh` → 8 passed, 0 failed
- `uv run pytest -q` → 931 passed
- `load_context.py` read order confirmed to include `.agents/rules/delegation.md` in second position

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgWfvyQPdH28MK8BN9AGGN)_