### PR TITLE
Make the proactive hooks quiet down on commands that succeeded

### DIFF
--- a/.agents/docs/reviews/pr35-checkpointing-codex-review-2026-09-03.md
+++ b/.agents/docs/reviews/pr35-checkpointing-codex-review-2026-09-03.md
@@ -1,0 +1,472 @@
+# PR #35 (merge `9d93caf`) — post-merge review: checkpointing fast retrieval + codex-delegation rewrite
+
+Date: 2026-09-03
+Reviewer: `general-purpose-opus`.
+**Codex could not be consulted — see section 6.** The caller required Codex as reviewer
+of record; that requirement is unmet and this report is not a substitute for it. Every
+judgment below is therefore backed by a *mechanical* check (PyYAML round-trip,
+end-to-end runs against the real script, the repo's own test suite) rather than by a
+second model's opinion.
+Scope reviewed: `.agents/skills/checkpointing/{SKILL.md,checkpoint.py,references/formats.md,refresh_guard.py}`,
+`tests/test_checkpoint.py`, `.agents/rules/codex-delegation.md`.
+Explicitly out of scope: `.agents/hooks/**` (owned by a parallel review).
+
+**Verdict: defects found** (1 medium cross-skill regression, 1 medium doc/behaviour
+mismatch, 3 low correctness/robustness items, 1 test-coverage gap). Nothing found is a
+data-loss or corruption bug in the happy path; the feature works and is idempotent.
+
+---
+
+## 1. What landed
+
+`checkpoint.py` gained a "fast retrieval" layer:
+
+- `_slugify` / `derive_slug` (`checkpoint.py:543,554`) — session slug from `--label`,
+  else dominant conventional-commit type + top keywords, else `session`.
+- `_sanitize_tag` / `derive_tags` (`:595,600`) — semantic tags from commit types,
+  top-level directories touched, `testing`/`skills`/`hooks`/`rules` markers, `codex`,
+  `agent-teams`, `team-{name}`.
+- `derive_headline` (`:640`) — first 3 commit subjects, whitespace-collapsed.
+- `_yaml_quote` / `build_frontmatter` / `parse_frontmatter` (`:651,657,691`).
+- `_escape_table_cell` / `_index_row` / `compose_index_md` (`:716,721,749`).
+- `generate_checkpoint` now prepends the frontmatter; `main` composes and writes
+  `.agents/checkpoints/INDEX.md` under the atomic-replace + content-hash guard.
+
+`refresh_guard.py` was **not** touched by `9d93caf` (`git show 9d93caf --stat` lists no
+such path) and operates exclusively on `.agents/STATE.md` — see its module docstring
+and `STATE_HEADING`/`CURRENT_BLOCK_RE` at `refresh_guard.py:63-66`. It never reads a
+checkpoint file, so "consistency with the new frontmatter format" is a non-question:
+it is out of the blast radius by construction.
+
+`codex-delegation.md` gained a "when in doubt, ask Codex" principle plus an explicit
+reconciliation note with `delegation.md`, five new consult triggers, and a
+"Hook-Detected Triggers" table.
+
+---
+
+## 2. Acceptance checks (verbatim)
+
+### 2.1 `python3 -m py_compile`
+
+```
+$ for f in .agents/skills/checkpointing/checkpoint.py .agents/skills/checkpointing/refresh_guard.py; do python3 -m py_compile "$f" && echo "OK $f"; done
+OK .agents/skills/checkpointing/checkpoint.py
+OK .agents/skills/checkpointing/refresh_guard.py
+```
+
+### 2.2 `bash .agents/check.sh`
+
+```
+PASS: INDEX.md links resolve
+PASS: Tier IDs present in tiers.md
+PASS: Model coherence
+PASS: .agents template paths in SAFE_DIRS
+PASS: Root orchestration contract
+PASS: Bootstrap references
+PASS: Native runtime boundaries
+PASS: Skill scripts and docs in sync
+
+Results: 8 passed, 0 failed
+```
+
+### 2.3 Checkpointing tests
+
+Exact command (`pytest` is not importable by the bare `python3`; the repo's own runner
+resolves it through `uv`):
+
+```
+$ python3 .agents/skills/_shared/run_tests.py --expect pass \
+    --target tests/test_checkpoint.py \
+    --target tests/test_collect_repo_state.py \
+    --target tests/test_refresh_guard.py --label pr35-review
+{"expected": "passed", "observed": "passed", "runner": "uv",
+ "command": ["uv", "run", "pytest", "-p", "no:cacheprovider", "tests/test_checkpoint.py",
+             "tests/test_collect_repo_state.py", "tests/test_refresh_guard.py"],
+ "exit_code": 0, "summary": "75 passed in 13.88s", "failed_tests": [],
+ "coverage_percent": null, "min_coverage": null,
+ "log_file": ".agents/logs/pr35-review.log", "ok": true}
+```
+
+### 2.4 End-to-end run in a scratch repository
+
+Scratch root: `/tmp/claude-0/-home-user-claude-code-orchestra/c862d471-81ee-5414-86f0-bd5b6c5db4a1/scratchpad/e2e`.
+The real `.agents/checkpoints/` was never written to.
+
+Run 1, commit subject `feat(core): add "quoted" | piped: colon thing`:
+
+```
+{"ok": true, "result": "applied",
+ "checkpoint_path": ".agents/checkpoints/2026-07-25-100000.md",
+ "index_path": ".agents/checkpoints/INDEX.md",
+ "slug": "feature-core-quoted-piped", "tags": ["feature"], ...}
+```
+
+Frontmatter written:
+
+```yaml
+---
+id: feature-core-quoted-piped-2026-07-25-100000
+timestamp: 2026-07-25-100000
+branch: "feature/adversarial"
+slug: feature-core-quoted-piped
+summary: "add \"quoted\" | piped: colon thing"
+tags: [feature]
+commits: 1
+files_changed: 0
+codex_consultations: 0
+agent_teams: 0
+---
+```
+
+Run 2, `--label 'weird | label: "x"'` and a >72-char commit subject containing `|`,
+`:` and `"`:
+
+```yaml
+---
+id: weird-label-x-2026-07-26-100000
+timestamp: 2026-07-26-100000
+branch: "feature/adversarial"
+slug: weird-label-x
+summary: "second | commit: with \"quotes\" and a very long subject line that goes on and on and on beyond seventy two characters for truncation; add \"quoted\" | piped: colon thing"
+tags: [bugfix, feature]
+commits: 2
+...
+---
+```
+
+Resulting `INDEX.md`:
+
+```markdown
+| Timestamp | Checkpoint | Branch | Tags | Stats | Summary |
+|---|---|---|---|---|---|
+| 2026-07-26-100000 | [weird-label-x](2026-07-26-100000.md) | feature/adversarial | bugfix, feature | 2c/0f | second \| commit: with "quotes" and a very long subject line that goes... |
+| 2026-07-25-100000 | [feature-core-quoted-piped](2026-07-25-100000.md) | feature/adversarial | feature | 1c/0f | add "quoted" \| piped: colon thing |
+```
+
+Idempotency, regenerating twice and comparing with what `--apply` wrote:
+
+```
+recompose stable: True
+matches disk    : True
+```
+
+So `|` escaping, `"` escaping, truncation and byte-stable regeneration all hold for
+the stated adversarial summary. **This part is clean.**
+
+---
+
+## 3. Answers to the framed questions
+
+### Q1. Is the emitted YAML guaranteed well-formed for adversarial input?
+
+**No — but only through the `tags:` flow sequence.** Verified with PyYAML against
+`build_frontmatter` output:
+
+| Input | Emitted | `yaml.safe_load` |
+|---|---|---|
+| commit subject with `"`, `:`, `|`, leading `-`, newline, very long | `summary: "…"` (escaped, newline collapsed by `derive_headline`) | **ok** |
+| branch `fix/"weird"\path` | `branch: "fix/\"weird\"\\path"` | **ok**, round-trips exactly |
+| zero commits / empty repo | `summary: "no commits"`, `tags: []`, `commits: 0` | **ok** |
+| Japanese-only / emoji-only summary or label | slug falls back to `session` | **ok** |
+| tag `#weird` (e.g. a top-level directory named `#weird`) | `tags: [feature, #weird]` | **FAIL** — `while parsing a flow sequence`; `, #` starts a YAML comment and the sequence is never closed |
+| tags `&anchor`, `*alias` | `tags: [&anchor, *alias]` | **FAIL** — `found undefined alias 'alias'` |
+| tag `team-a: b` (from an Agent Teams `name`) | `tags: [team-a: b]` | parses, but as `[{'team-a': 'b'}]` — a mapping, not the string |
+| tag `{x}` | `tags: [{x}]` | parses as `[{'x': None}]` |
+| `--label No` | `slug: no` | parses as `slug: False` (YAML 1.1 boolean) |
+
+`_yaml_quote` / `parse_frontmatter` round-trip correctly for backslash/quote
+combinations (`a\"`, `\\`, `"\`, `\\"` all verified) — the ordering of the two
+`.replace()` calls happens to be safe.
+
+### Q2. Is `INDEX.md` regeneration idempotent and non-lossy?
+
+**Idempotent: yes**, verified byte-identical (above). Fully regenerated from disk, so a
+deleted checkpoint disappears (pinned by `test_the_index_is_rebuilt_not_appended`).
+
+**Non-lossy: mostly.** A frontmatter-less checkpoint still gets a row keyed on its stem
+(pinned by test). A hand-edited `INDEX.md` is *not* silently overwritten — the
+`atomic_replace` content-hash guard aborts with exit 3; but see defect D4 for the
+ordering consequence.
+
+**Malformed frontmatter is not handled.** A checkpoint whose frontmatter opens with
+`---` and never closes makes `parse_frontmatter` (`checkpoint.py:703-704` — the loop
+only `break`s on a closing fence, and falls through to the end of file otherwise) read
+the entire document body as key/value pairs. Reproduced:
+
+```
+| 2026-01-01-000000 | [broken] (x.md](2026-01-01-000000.md) | a\|b | a, b, c, d, e | 999c/0f | injected \| row |
+```
+
+`|` is correctly escaped everywhere, including in the link label — but `]`, `[` and `(`
+are not, so the markdown link is destroyed and the label leaks into the cell (D3).
+Row count is preserved; nothing is dropped.
+
+### Q3. Slug/tag collision in the same timestamp bucket?
+
+**No, and no silent overwrite.** `main` (`checkpoint.py:1515-1524`) refuses to proceed
+when `.agents/checkpoints/{timestamp}.md` already exists, emitting
+`"… already exists; pass a distinct --now"` and exiting 3 before anything is written.
+The slug is metadata only; `id: {slug}-{timestamp}` is unique via the timestamp; slugs
+are never used as a dict key or a filename. The `pending`-wins-over-disk merge in
+`compose_index_md` (`:757-759`) is only reachable after that collision check passed,
+i.e. when no on-disk file exists for that stem.
+
+### Q4. Does `codex-delegation.md` contradict `delegation.md`?
+
+**No hard contradiction.** The merge explicitly reconciled them: `codex-delegation.md:9-14`
+subordinates itself to `delegation.md` ("it does not override that file's Self-Handle
+List or its over-delegation anti-pattern — a known one-line edit stays a one-line
+edit"), and its "Do NOT delegate to Codex" list (`:57-67`) routes routine work to
+`general-purpose-sonnet` and analysis/research to `general-purpose-opus`, matching
+`delegation.md`'s Route Selection table.
+
+Two soft tensions, neither introduced by this PR and neither worth a fix commit:
+
+- `codex-delegation.md:29` "Default to Codex-first delegation for development tasks."
+  is broader than `delegation.md`'s route table, which sends implementation to
+  `general-purpose-sonnet` / `general-purpose-opus` and reserves Codex for
+  "Architecture, planning, decomposition, complex algorithms, code review". Present
+  verbatim in the pre-merge baseline (`git show 31ef837:.agents/rules/codex-delegation.md`
+  line 29) — pre-existing, and the "Do NOT delegate" list below it resolves it in
+  practice.
+- The scope note says "a known one-line edit"; `delegation.md`'s Self-Handle List item 2
+  says "roughly 20 lines or fewer". Narrower phrasing, not a conflicting rule.
+
+The new hook table's thresholds were checked against the real hooks:
+`post-implementation-review.py:57-58` has `MIN_FILES_FOR_REVIEW = 2` and
+`MIN_LINES_FOR_REVIEW = 50`, matching the "2+ files or 50+ lines" row; all six named
+hook files exist in `.agents/hooks/`. One row is wrong — see D2.
+
+### Q5. Is `refresh_guard.py` consistent with the new frontmatter?
+
+**Out of scope by construction, so trivially consistent.** It was not modified by
+`9d93caf`, it reads and writes only `.agents/STATE.md`, and it contains no checkpoint
+path, glob, or frontmatter handling. `tests/test_refresh_guard.py` passes unchanged.
+
+### Q6. Downstream regressions from prepending frontmatter?
+
+**Yes — one, in the catchup skill.** See D1.
+`.agents/skills/context-loader/load_context.py:69` keys on the `PROGRESS.md` entry
+header regex, not the checkpoint body, and is unaffected.
+`get_checkpoint_files` (`checkpoint.py:1043-1047`) filters on `CHECKPOINT_STEM_RE`, so
+`INDEX.md` is correctly never treated as a checkpoint and never enters `PROGRESS.md`
+(pinned by `test_the_index_is_never_mistaken_for_a_checkpoint`).
+
+### Q7. Do the docs match the code?
+
+Yes, on every checked point:
+
+- Key list and **order** in `references/formats.md:31-43` matches `build_frontmatter`
+  (`checkpoint.py:671-686`) exactly, including the conditional `since:`.
+- `--label`, the four preview files, and the `--json` payload keys in `SKILL.md` match.
+- "~14 lines" matches the 14-line maximum block.
+- `formats.md:214-217` claims for `INDEX.md` only "preview by default, `--apply`,
+  atomic replace, and a content-hash concurrent-modification guard" — deliberately
+  omitting the *validation* callback that `PROGRESS.md` and `STATE.md` get. That is
+  accurate; considered and dismissed as a defect.
+- `formats.md:200-201`'s claim that "`|` is escaped so a value cannot break out of its
+  column" is true; the claim does not extend to `]`/`(` (D3).
+
+---
+
+## 4. Defects
+
+### D1 — medium — `.agents/skills/catchup/collect_repo_state.py:559-575` (with `:130-148`)
+
+`collect_checkpoints` returns `file_info(path)`, whose contract is "first non-empty
+line". Since `9d93caf` every checkpoint's first non-empty line is the frontmatter fence
+`---`, so the catchup collector now reports a constant, information-free string for
+every checkpoint. Reproduced against the scratch repo:
+
+```json
+{"present": true, "items": [
+  {"file": "2026-07-26-100000.md", "present": true, "first_line": "---", "error": null},
+  {"file": "2026-07-25-100000.md", "present": true, "first_line": "---", "error": null}]}
+```
+
+`.agents/skills/catchup/SKILL.md:82` still documents this field as
+"`checkpoints` — newest 5 (file + first heading)". The whole point of the field — give
+`/catchup` a one-glance name for each recent session — is silently dead, and the new
+frontmatter contains a *better* answer (`summary`, `slug`) that is not used.
+`tests/test_collect_repo_state.py:334-344` does not catch it because its fixture writes
+a frontmatter-less checkpoint.
+
+**Minimal fix**: in `collect_checkpoints`, skip a leading frontmatter block before
+taking the first heading — e.g. read the file, and if it starts with `---`, prefer
+`checkpoint.parse_frontmatter`-style `summary`/`slug`, else take the first line after
+the closing fence. A ~10-line local helper in `collect_repo_state.py`; do not import
+`checkpoint.py`. Add a regression test with a frontmatter-bearing checkpoint.
+
+### D2 — medium — `.agents/rules/codex-delegation.md:77` (and the paragraph at `:69-70`)
+
+The row `| Any Bash error or non-zero exit | error-to-codex.py | codex-debugger |`
+misdescribes the hook. `error-to-codex.py` fires on *output pattern matching*
+independently of the exit code: `_detect_errors` (`error-to-codex.py:144-158`) returns
+a hint on one `STRONG_ERROR_PATTERNS` match or `MIN_WEAK_SIGNALS = 2` weak matches,
+and `main` (`:195-199`) reports `"N error pattern(s) found in command output"` before
+it ever looks at the exit code. During this review the hook fired three times on
+successful (exit 0) read-only commands — `git show` of a diff, `cat` of a rules file,
+`--help` output — purely because the *text being read* contained the words
+`error`/`Error:`/`FAIL`.
+
+Combined with `:69-70` ("treat each hint as a prompt to route, not as noise to
+dismiss"), the rule now instructs the agent to escalate to `codex-debugger` on hints
+that routinely fire when nothing failed. That is a real cost: an unnecessary Codex
+round trip per false positive.
+
+**Minimal fix**: change the row's Situation cell to "Bash output matches error
+patterns, or a non-zero exit", and append one sentence to `:69-70`: "Confirm the
+command actually failed (non-zero exit, or a real error in the output rather than a
+quoted one) before routing; the Bash hook matches text and fires on read-only commands
+that merely display error-shaped output." Doc-only, no hook change (hooks are out of
+scope).
+
+### D3 — low — `.agents/skills/checkpointing/checkpoint.py:595-597` and `:740`
+
+Two related escaping gaps.
+
+(a) `_sanitize_tag` strips only `[`, `]`, `|`, `,` and whitespace. A tag reaching
+`tags: [...]` through a top-level directory name (`derive_tags`, `:614-616`) or an
+Agent Teams `team-{name}` (`:634-637`) can still contain `#`, `&`, `*`, `:`, `{`, `}`,
+which respectively break the flow sequence, become an undefined alias, or silently turn
+the tag into a mapping — see the Q1 table. The repo's own `parse_frontmatter` never
+notices, so the damage is confined to any external YAML reader and to a human reading
+the block, which is exactly the audience the frontmatter was added for.
+
+(b) `_index_row:740` builds the link cell as `f"[{_escape_table_cell(slug)}]({stem}.md)"`.
+`_escape_table_cell` escapes `|` and newlines only, so a `slug` containing `]` or `(` —
+reachable only from a malformed/hand-edited frontmatter — destroys the markdown link.
+
+**Minimal fix**: (a) widen the `_sanitize_tag` character class to
+`r"[^A-Za-z0-9._/-]+"` (allow-list rather than deny-list) and re-strip leading/trailing
+`-`; (b) at `:740`, pass the slug through the same allow-list, or fall back to `stem`
+when the slug contains `[]()`.
+
+### D4 — low — `.agents/skills/checkpointing/checkpoint.py:1648-1651` (ordering)
+
+The `INDEX.md` write sits *between* the `PROGRESS.md` write and the `STATE.md` Progress
+Tracker insert. `INDEX.md` is fully derivable from the checkpoints, yet a failed
+content-hash guard on it (a hand-edited or concurrently written index) returns exit 3
+and skips the `STATE.md` update, leaving the repository with a new checkpoint and
+`PROGRESS.md` entry but no tracker link — a worse end state than a stale index.
+
+**Minimal fix**: move the `INDEX.md` `atomic_replace` call to *after* the `STATE.md`
+block, or keep the position and downgrade its failure to a `payload["warnings"]` entry
+(the index is regenerated on the next run anyway, which is the stated design).
+
+### D5 — low — `.agents/skills/checkpointing/checkpoint.py:691-714` (`parse_frontmatter`)
+
+An unterminated frontmatter block (opening `---`, no closing fence) makes the loop read
+the whole document, so ordinary body lines containing a colon become fields. Reproduced
+above: a body line `commits: 999` and `summary: injected | row` were both promoted into
+the index row. The docstring promises only that a *missing* block yields `{}`; a
+*malformed* one silently yields garbage.
+
+**Minimal fix**: scan for the closing fence first and return `{}` when there is none
+(two extra lines: find the index of the next `---` in `lines[1:]`, return `{}` if
+absent, iterate only up to it).
+
+### D6 — low — `tests/test_checkpoint.py` (coverage gap)
+
+Of the ten new functions, `derive_tags`, `_sanitize_tag`, `derive_headline`,
+`_escape_table_cell` and `_index_row` have no direct test (`grep` over the file finds
+only `compose_index_md` at `:669,679`). Nothing pins: the `|`-escaping that
+`references/formats.md:211` advertises, the tag derivation rules that
+`references/formats.md:31-38` documents, the 72-char truncation, the 5-tag cap, or the
+byte-stable regeneration that the design depends on. `.agents/rules/testing.md`
+("Edge cases: … special characters") asks for exactly these.
+
+**Minimal fix**: add three tests —
+`test_a_pipe_in_the_summary_stays_inside_its_index_column`,
+`test_regenerating_the_index_is_byte_identical`, and
+`test_tags_name_the_commit_types_and_directories_touched`.
+
+---
+
+## 5. Non-defects considered and dismissed
+
+- `INDEX.md` mistaken for a checkpoint — correctly excluded by `CHECKPOINT_STEM_RE`
+  in both `checkpoint.py:1043-1047` and `collect_repo_state.py:565`. Verified.
+- `--label` with punctuation/non-ASCII — `_slugify` + `or DEFAULT_SLUG` handles it;
+  `'weird | label: "x"'` → `weird-label-x`, verified end to end.
+- Commit subject containing `"`, `\`, `:`, newline, leading `-`, or a very long line —
+  correctly quoted/escaped/collapsed; PyYAML round-trips it.
+- `_yaml_quote` / `parse_frontmatter` escape-order bug — checked four adversarial
+  backslash/quote combinations; the round trip is exact.
+- Same-second checkpoint collision — refused with exit 3 before any write.
+- `formats.md`'s "same Writer Safety Contract as `PROGRESS.md`" claim — the parenthesis
+  enumerates only the four guarantees the index actually gets, omitting the validation
+  callback. Accurate as written.
+- `refresh_guard.py` — untouched, and structurally unable to see a checkpoint file.
+- The "Hook-Detected Triggers" table's six hook filenames and the 2-file/50-line
+  threshold — all verified against `.agents/hooks/`.
+- Frontmatter-less legacy checkpoints — still get an index row (pinned by test,
+  re-verified in the scratch repo).
+
+---
+
+## 6. Codex consultation record — BLOCKED
+
+Codex was invoked as required and **could not complete**. Two independent failures:
+
+1. First attempt returned
+   `{"ok": false, "error": "codex CLI not found on PATH; install with `npm install -g @openai/codex@latest`"}`.
+   The CLI was then installed: `npm install -g @openai/codex@latest` → `codex-cli 0.153.0`
+   at `/opt/node22/bin/codex`.
+
+2. Second attempt, with the CLI present:
+
+   ```
+   python3 .agents/skills/_shared/codex_consult.py \
+     --prompt-file <scratchpad>/codex/prompt.md \
+     --label pr35-checkpointing-review --caller general-purpose-opus \
+     --sandbox read-only --timeout 1400
+   ```
+
+   Result after 1400 s:
+
+   ```json
+   {"ok": false, "exit_code": null, "model": "gpt-5.6-sol", "caller": "general-purpose-opus",
+    "sandbox": "read-only", "timed_out": true, "duration_sec": 1400.01,
+    "response_chars": 0, "response_head": "",
+    "error": "codex exec timed out after 1400s"}
+   ```
+
+   Root cause: this environment's egress proxy denies Codex's API host by policy.
+   `curl -sS "$HTTPS_PROXY/__agentproxy/status"` reports repeated
+   `connect_rejected` / `gateway answered 403 to CONNECT (policy denial or upstream
+   failure)` for `api.openai.com:443` (and `ab.chatgpt.com:443`), 90 such failures
+   during the run. `codex exec` started, printed its banner and the prompt, and then
+   hung with no model output.
+
+   The wrapper's `edits.created_files` for that run lists
+   `.agents/docs/reviews/pr35-checkpointing-codex-review-2026-09-03.md`. That is **this
+   report**, written by me while the consult was blocked, not a Codex edit — the
+   provenance tracker attributes any tree change during the call window to the callee.
+   Codex ran `--sandbox read-only` and produced zero bytes.
+
+A third label (`pr35-codex-ping`) confirms the same zero-byte outcome, so this is
+environmental and not prompt-specific. Codex is unavailable here until the proxy allows
+`api.openai.com`; re-running the consult is the correct follow-up once it does. The
+prompt is preserved verbatim at
+`.agents/logs/codex/20260903T190614Z-pr35-checkpointing-review.prompt.md` and can be
+replayed unchanged.
+
+## 7. What replaced Codex's judgment
+
+Because Codex was unavailable, each question that would have been Codex's call was
+turned into an executable check instead:
+
+| Question | Substitute check |
+|---|---|
+| Q1 YAML well-formedness | `yaml.safe_load` (PyYAML) run over `build_frontmatter` output for 9 adversarial inputs — table in section 3 |
+| Q2 idempotency / losslessness | two `compose_index_md` calls compared byte-for-byte against what `--apply` wrote, plus a hand-crafted malformed-frontmatter checkpoint |
+| Q3 collision | read of `main`'s pre-write existence guard, `checkpoint.py:1515-1524` |
+| Q4 rule conflict | line-by-line diff of both rule files against the `31ef837` baseline, plus verification of the hook table against `.agents/hooks/` |
+| Q5 `refresh_guard.py` | `git show 9d93caf --stat` (not in the diff) plus a grep for checkpoint/frontmatter handling (none) |
+| Q6 downstream | `collect_repo_state.py` run against the scratch repo containing new-format checkpoints |
+| Q7 doc/code | key-by-key comparison of `references/formats.md` and `SKILL.md` against `build_frontmatter` and `main` |
+
+These establish the *facts* in section 4 conclusively. What they cannot supply is the
+second opinion on severity and on the right minimal fix; treat the severities as mine
+alone.

--- a/.agents/docs/reviews/pr35-checkpointing-fix-evidence-2026-09-03.md
+++ b/.agents/docs/reviews/pr35-checkpointing-fix-evidence-2026-09-03.md
@@ -1,0 +1,194 @@
+# PR #35 follow-up — fix evidence (D1–D6)
+
+Date: 2026-09-03. Author: `general-purpose-opus`. Branch: `claude/resolve-pr-conflicts-agkoey`.
+Companion to `.agents/docs/reviews/pr35-checkpointing-codex-review-2026-09-03.md`.
+`9d93caf` was **not** reverted; the frontmatter/INDEX feature is intact. No test was
+weakened, skipped or deleted. Nothing under `.agents/hooks/**` was touched.
+Codex was again unreachable (proxy denies CONNECT to `api.openai.com`), so every claim
+below is backed by an executable check.
+
+## 1. Changes, per defect
+
+### D1 — `.agents/skills/catchup/collect_repo_state.py`, `.agents/skills/catchup/SKILL.md`
+New module-local helpers `_first_meaningful_line`, `_unquote_frontmatter_value` and
+`checkpoint_info`; `collect_checkpoints` now calls `checkpoint_info` instead of
+`file_info`. Precedence: frontmatter `summary` → `slug` → first non-empty body line.
+`checkpoint.py` is **not** imported — the reader is 25 lines and knows two keys, so the
+two skills stay decoupled. `file_info` is unchanged and still serves rules/skills/agents.
+`SKILL.md` now states what the field holds instead of "first heading".
+
+An *unterminated* block is treated as "no frontmatter" (first non-empty line, i.e. the
+fence). That is deliberate and mirrors the D5 decision in `checkpoint.py`: with no
+closing fence there is no way to tell a field from a body line. It is pinned by the test
+so the behaviour is a decision, not an accident.
+
+### D2 — `.agents/rules/codex-delegation.md`
+Situation cell → "Bash output matches error patterns, or a non-zero exit"; one sentence
+added to the paragraph above the table requiring confirmation of an actual failure
+before routing to `codex-debugger`. Doc-only.
+
+**Integration conflict to resolve before merge**: the parallel agent's uncommitted edit
+to `.agents/hooks/error-to-codex.py` *deletes* the exit-code path entirely (`_exit_code`
+removed, `build_context` returns `None` when no pattern matches) and raises
+`MIN_WEAK_SIGNALS` 2 → 3. If that lands, the tail "or a non-zero exit" becomes false and
+the cell should read just "Bash output matches error patterns". I left the wording the
+task specified because the hook is outside my scope and may still change.
+
+### D3 — `.agents/skills/checkpointing/checkpoint.py`
+(a) New module constant `TAG_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._/-]+")`; `_sanitize_tag`
+uses it (allow-list) and still re-strips `-`. (b) `_index_row` builds the link label from
+`_sanitize_tag(fields.get("slug", "")) or stem`, so `]`/`(`/`[` can no longer escape the
+markdown link, and an emptied slug falls back to the stem.
+
+### D4 — `.agents/skills/checkpointing/checkpoint.py`
+The `INDEX.md` `atomic_replace` moved below the `STATE.md` block, with a comment naming
+the reason. Order is now checkpoint+prompt → `PROGRESS.md` → `STATE.md` → `INDEX.md`.
+`payload["artifacts"]` is unchanged (it is a set of paths, not an order).
+
+### D5 — `.agents/skills/checkpointing/checkpoint.py`
+`parse_frontmatter` locates the closing fence first and returns `{}` when there is none,
+iterating only `lines[1:closing]`. Docstring extended to state the malformed case.
+
+### D6 — `tests/`
+Seven tests added (six for D6/D3/D5/D4, one for D1):
+
+- `tests/test_checkpoint.py::test_tags_name_the_commit_types_and_directories_touched`
+- `…::test_a_tag_cannot_break_the_frontmatter_flow_sequence`
+- `…::test_a_pipe_in_the_summary_stays_inside_its_index_column`
+- `…::test_a_bracket_in_the_slug_cannot_break_the_index_link`
+- `…::test_an_unterminated_frontmatter_block_yields_no_fields`
+- `…::test_regenerating_the_index_is_byte_identical`
+- `…::test_a_failed_index_write_does_not_orphan_the_state_tracker`
+- `tests/test_collect_repo_state.py::test_a_checkpoint_is_named_by_its_frontmatter_not_by_the_fence`
+
+The D4 test is the only in-process one: it monkeypatches `cp.atomic_replace` to fail for
+`INDEX.md` only and `sys.argv`, then calls `cp.main()`. A subprocess run cannot reach the
+ordering, because making `INDEX.md` unreadable aborts earlier, at the pre-write read
+(`checkpoint.py:1557-1564`).
+
+## 2. Acceptance checks (verbatim)
+
+### 2.1 py_compile
+
+```
+OK .agents/skills/catchup/collect_repo_state.py
+OK .agents/skills/checkpointing/checkpoint.py
+OK tests/test_checkpoint.py
+OK tests/test_collect_repo_state.py
+```
+
+### 2.2 `bash .agents/check.sh`
+
+```
+PASS: INDEX.md links resolve
+PASS: Tier IDs present in tiers.md
+PASS: Model coherence
+PASS: .agents template paths in SAFE_DIRS
+PASS: Root orchestration contract
+PASS: Bootstrap references
+PASS: Native runtime boundaries
+PASS: Skill scripts and docs in sync
+
+Results: 8 passed, 0 failed
+```
+
+### 2.3 Full suite
+
+```
+$ python3 .agents/skills/_shared/run_tests.py --expect pass --target tests/ --label pr35-ckptfix
+{"expected": "passed", "observed": "passed", "runner": "uv",
+ "command": ["uv", "run", "pytest", "-p", "no:cacheprovider", "tests/"],
+ "exit_code": 0, "summary": "975 passed in 89.14s (0:01:29)", "failed_tests": [],
+ "coverage_percent": null, "min_coverage": null,
+ "log_file": ".agents/logs/pr35-ckptfix.log", "ok": true}
+```
+
+975 includes the parallel agent's hook tests (`tests/test_post_bash_check.py`,
+untracked `tests/test_hook_thresholds.py`); none failed.
+
+One intermediate red, worth recording: the first run reported
+`1 failed … test_a_failed_index_write_does_not_orphan_the_state_tracker`, asserting
+`STAMP in state`. The *fix* was working — the tracker block was inserted — but the
+tracker is a link to `PROGRESS.md`, not a timestamp. The assertion, not the code, was
+wrong; it now checks the checkpoint file, the `PROGRESS.md` entry and the
+`## Progress Tracker` block.
+
+## 3. Reproductions, before and after
+
+Scratch repo: `<scratchpad>/fix/e2e`. The real `.agents/checkpoints/` was never written.
+"before" runs use `git show HEAD:` copies of both scripts.
+
+### D1 — `first_line` for a frontmatter-bearing checkpoint
+
+Checkpoint written by the real script from commit
+`feat(core): add "fast" retrieval | catalog`:
+
+```yaml
+---
+id: feature-core-fast-retrieval-2026-07-25-100000
+timestamp: 2026-07-25-100000
+branch: "master"
+slug: feature-core-fast-retrieval
+summary: "add \"fast\" retrieval | catalog"
+tags: [feature]
+...
+---
+```
+
+```
+before: {"present": true, "items": [{"file": "2026-07-25-100000.md", "present": true,
+         "first_line": "---", "error": null}]}
+after : {"present": true, "items": [{"file": "2026-07-25-100000.md", "present": true,
+         "first_line": "add \"fast\" retrieval | catalog", "error": null}]}
+```
+
+### D3a — tags from `#weird/`, `&anchor/`, `*alias/`, `{brace}/` and team `a: b`
+
+before:
+
+```
+tags: [#weird, &anchor, *alias, agent-teams, brace, team-a: b, weird]
+yaml.parser.ParserError: while parsing a flow sequence
+  in "<unicode string>", line 7, column 7: expected ',' or ']', but got ':'
+```
+
+after:
+
+```
+tags   : ['agent-teams', 'alias', 'anchor', 'brace', 'team-a-b', 'weird']
+emitted: tags: [agent-teams, alias, anchor, brace, team-a-b, weird]
+yaml.safe_load: ok
+     tags parsed: ['agent-teams', 'alias', 'anchor', 'brace', 'team-a-b', 'weird']
+```
+
+### D3b — slug `broken] (x`
+
+after: `| 2026-01-01-000000 | [broken-x](2026-01-01-000000.md) | - |  | 0c/0f | s |`
+(before: `| [broken] (x](2026-01-01-000000.md) |` — link destroyed.)
+
+### D5 — unterminated frontmatter
+
+Input: `---\nslug: broken] (x\ntags: [a, b, c, d, e]\n\n# Body\n\ncommits: 999\nsummary: injected | row\n`
+
+```
+after: parse_frontmatter: {}
+       index row        : | 2026-01-01-000000 | [2026-01-01-000000](2026-01-01-000000.md) | - |  | 0c/0f | - |
+```
+
+Before, `commits: 999` and `summary: injected | row` were promoted out of the body and
+into the index row.
+
+## 4. Judgment calls that went unreviewed
+
+Codex could not be consulted, so these are mine alone:
+
+1. Unterminated frontmatter yields `{}` (metadata lost) rather than a best-effort parse.
+   Losing metadata on a malformed file is safer than promoting body text, but it does
+   mean a truncated write shows an empty row instead of a partial one.
+2. `_sanitize_tag` is now applied to the *slug* in the index link. The slug is already
+   slugified on the write path, so this only affects hand-edited or foreign frontmatter,
+   but it does mean the link label can differ from the `slug:` field in that case.
+3. D4 was fixed by reordering rather than by downgrading to a warning. Reordering keeps
+   the failure loud; a stale index still aborts the run with exit 3 after `STATE.md` is
+   written, so the operator still learns about it.
+4. The D2 wording, given the parallel hook rework (section 1, D2).

--- a/.agents/docs/reviews/pr35-hooks-codex-review-2026-09-03.md
+++ b/.agents/docs/reviews/pr35-hooks-codex-review-2026-09-03.md
@@ -1,0 +1,516 @@
+# PR #35 hook review — merge 9d93caf (2026-09-03)
+
+Scope: the five hooks under `.agents/hooks/` touched by merge commit `9d93caf`
+(`agent-router.py`, `check-codex-before-write.py`, `error-to-codex.py`,
+`post-test-analysis.py`, `post-implementation-review.py`) plus their only test,
+`tests/test_post_bash_check.py`. Out of scope and untouched:
+`.agents/skills/checkpointing/**`, `.agents/rules/codex-delegation.md`.
+
+**Verdict: defects found (11).**
+
+## 0. Codex could not be reached — the mandated reviewer of record is missing
+
+The review was to be arbitrated by Codex. It could not be:
+
+```
+$ python3 .agents/skills/_shared/codex_consult.py \
+    --prompt-file .agents/logs/codex/prompt-pr35-hooks-review.md \
+    --label pr35-hooks-review --caller general-purpose-opus \
+    --sandbox read-only --timeout 840
+{"ok": false, "exit_code": null, "model": "gpt-5.6-sol", "caller": "general-purpose-opus",
+ "label": "pr35-hooks-review", "sandbox": "read-only", "write_access": false,
+ "timed_out": true, "duration_sec": 840.027, "response_chars": 0,
+ "error": "codex exec timed out after 840s"}
+```
+
+Cause, from `.agents/logs/codex/20260903T190734Z-pr35-hooks-review.err.log`:
+
+```
+ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket:
+  URL error: Proxy connection failed: HTTP CONNECT failed with status 403,
+  url: wss://api.openai.com/v1/responses
+warning: Falling back from WebSockets to HTTPS transport. stream disconnected before completion
+ERROR: Reconnecting... waiting for network   (repeated until the 840s deadline)
+```
+
+`curl -sS "$HTTPS_PROXY/__agentproxy/status"` confirms the egress proxy is denying
+the destination, not that the invocation was malformed:
+
+```
+"recentRelayFailures": [ { "kind": "connect_rejected",
+  "detail": "gateway answered 403 to CONNECT (policy denial or upstream failure)",
+  "host": "api.openai.com:443" }, ... ]
+```
+
+Reproduced with a one-word prompt ("Reply with the single word: ONLINE"), so it is
+not prompt size:
+
+```
+{'ok': False, 'error': 'codex exec timed out after 150s', 'response_chars': 0, 'duration_sec': 150.05}
+```
+
+Consequence for the reader: everything below is *my* analysis, backed by executed
+evidence rather than by Codex's judgment. The prompt that Codex would have answered
+is preserved verbatim at
+`.agents/logs/codex/20260903T190734Z-pr35-hooks-review.prompt.md`; re-run the command
+above from an environment with egress to `api.openai.com` to get the arbitration this
+review is missing. Two judgment calls I flag as *unarbitrated*: whether D10
+(post-implementation-review thresholds) is a defect or a taste call, and whether D2
+should be deleted or repaired.
+
+## 1. Acceptance checks
+
+### py_compile
+
+```
+$ for f in agent-router check-codex-before-write error-to-codex post-test-analysis post-implementation-review; do
+    python3 -m py_compile ".agents/hooks/$f.py" && echo "OK $f.py"; done
+OK agent-router.py
+OK check-codex-before-write.py
+OK error-to-codex.py
+OK post-test-analysis.py
+OK post-implementation-review.py
+```
+
+### .agents/check.sh
+
+```
+$ bash .agents/check.sh
+PASS: INDEX.md links resolve
+PASS: Tier IDs present in tiers.md
+PASS: Model coherence
+PASS: .agents template paths in SAFE_DIRS
+PASS: Root orchestration contract
+PASS: Bootstrap references
+PASS: Native runtime boundaries
+PASS: Skill scripts and docs in sync
+
+Results: 8 passed, 0 failed
+```
+
+### Test suite
+
+`python3 -m pytest` is not available (`No module named pytest`); the project runs
+tests through `uv`.
+
+```
+$ uv run pytest tests/ -q
+...
+tests/test_write_guide.py ...................                            [100%]
+======================= 967 passed in 104.62s (0:01:44) ========================
+```
+
+The only test touching these five hooks is `tests/test_post_bash_check.py` (8 tests,
+all green). It covers `error-to-codex` and `post-test-analysis` through the
+dispatcher only. There is **no test at all** for `agent-router.py`,
+`check-codex-before-write.py`, or `post-implementation-review.py`.
+
+```
+$ uv run pytest tests/test_post_bash_check.py -v
+tests/test_post_bash_check.py::test_traceback_output_triggers_debugging_hint PASSED [ 12%]
+tests/test_post_bash_check.py::test_pytest_failure_dedups_generic_error_hint PASSED [ 25%]
+tests/test_post_bash_check.py::test_codex_exec_command_logs_jsonl_and_confirms PASSED [ 37%]
+tests/test_post_bash_check.py::test_codex_wrapper_call_logs_jsonl PASSED [ 50%]
+tests/test_post_bash_check.py::test_peer_cli_wrapper_call_logs_its_callee PASSED [ 62%]
+tests/test_post_bash_check.py::test_wrapper_help_call_is_not_logged PASSED [ 75%]
+tests/test_post_bash_check.py::test_benign_output_produces_no_hint PASSED [ 87%]
+tests/test_post_bash_check.py::test_malformed_stdin_does_not_crash PASSED [100%]
+============================== 8 passed in 0.30s ===============================
+```
+
+That green run is itself evidence — see D1: the hook fired on it.
+
+## 2. Live evidence collected inside a real Claude Code session
+
+These are not simulations; they are hook outputs observed in this session.
+
+**L1 — a fully green test run reported as a failure.** The `-v` run above printed
+`8 passed` and zero failures. The session then received:
+
+```
+[Codex Debug Suggestion] Test failure with error details (2 issues). Use the
+`codex-debugger` subagent before attempting a manual fix ...
+```
+
+The "2 issues" are the substring `error` inside the test *names*
+`test_pytest_failure_dedups_generic_error_hint` and
+`test_traceback_output_triggers_debugging_hint` — matched by the bare
+`r"ERROR"`/`r"Error:"` patterns under `re.IGNORECASE`.
+
+**L2 — the error hook is blind on the failing commands it exists for.**
+
+```
+$ printf 'Traceback (most recent call last):\n  x\n'; true      # exit 0
+-> [Error Detected] 1 error pattern(s) found in command output. ...   (FIRED)
+
+$ printf 'Traceback (most recent call last):\n  x\n'; exit 1     # byte-identical output, exit 1
+-> (no hook output at all)
+
+$ printf 'alpha beta gamma delta epsilon\n'; exit 7
+-> (no hook output at all)
+```
+
+Identical stdout, identical patterns; the only difference is the exit status. On a
+non-zero exit the hook emits nothing, so in the real runtime the payload does not
+expose the output under `stdout`/`content` (or the hook is not reached at all). The
+new "fire on non-zero exit" branch therefore never runs in production — it is green
+only because `tests/test_post_bash_check.py:34-39` invents the payload shape
+`{"stdout": ..., "exit_code": 1}`.
+
+**L3 — cry-wolf on successful commands.** `git show 9d93caf -- .agents/hooks/`
+(exit 0, a successful read of the very diff under review) produced:
+
+```
+[Error Detected] 8 error pattern(s) found in command output. ...
+```
+
+A later successful `grep`+`python3 -c` combination produced
+`[Error Detected] 2 error pattern(s) found in command output.` Both commands
+succeeded. The words `deprecated`, `timeout`, `Error:`, `FAILED` in ordinary
+*content* are enough.
+
+## 3. Offline harness (pure `build_context` / `should_suggest_codex` calls)
+
+Harness: `/tmp/.../scratchpad/harness.py` and `router.py`; both load the hooks by
+path and call their pure functions.
+
+### error-to-codex.py
+
+```
+quiet | grep no match (exit 1, empty stdout)
+quiet | grep -c no match (exit 1, stdout "0")
+FIRE  | diff a.txt b.txt with differences (exit 1) -> "command exited with code 1 - likely a silent failure"
+quiet | git diff --quiet (exit 1, empty)
+quiet | test -f nope (exit 1, empty)
+quiet | [ 1 -eq 2 ] (exit 1, empty)
+FIRE  | python3 -c 'print("maybe")'; exit 1 -> "command exited with code 1 - likely a silent failure"
+FIRE  | pip install output w/ "deprecated" + "Could not" (exit 0) -> 2 error pattern(s)
+FIRE  | curl output "timed out, retrying" + "Unable to" (exit 0) -> 2 error pattern(s)
+FIRE  | real traceback (exit 1) -> 2 error pattern(s)          [correct]
+quiet | "Build complete in 3s" (exit 0)                        [correct]
+```
+
+The benign *silent* non-zero exits (`grep` no-match, `test`, `[`, `git diff --quiet`)
+are saved by the pre-existing empty-output guard at line 177, not by the new logic.
+The benign *loud* non-zero exits (`diff` with differences) fire.
+
+### post-test-analysis.py
+
+```
+FIRE  | GREEN pytest, test name contains "error" -> "Test failure with error details (1 issue)"
+quiet | GREEN pytest plain ("8 passed in 0.30s")
+quiet | GREEN ruff ("All checks passed!")
+FIRE  | GREEN mypy "Success: no issues found in 1 source file (src/errors.py)" -> "Test failure with error details (1 issue)"
+FIRE  | 1 real failure (FAILED + AssertionError) -> "Multiple failures detected (4 issues)"   [fires correctly, count inflated 4x from one failure]
+```
+
+### check-codex-before-write.py
+
+```
+quiet | one-line docs edit ("Fix a typo in the sentence.")
+FIRE  | 210 chars of plain docs text -> "Creating new file with meaningful content"
+quiet | README.md (SIMPLE_EDIT_PATTERNS)
+FIRE  | /repo/__pycache__/x.pyc -> "File path contains 'cache' - likely a design decision"
+FIRE  | .agents/hooks/agent-router.py -> "File path contains 'router' - likely a design decision"
+FIRE  | prose "we should design later" in notes.txt -> "Content contains 'design'"
+FIRE  | "typedef struct A A;\ntypedef struct B B;\n" -> "2 definitions in one write - structural change"
+FIRE  | "#ifdef FOO\n#ifdef BAR\n#endif\n#endif\n" -> "2 definitions in one write - structural change"
+FIRE  | "The def of the term.\nAnother def of it.\n" -> "2 definitions in one write - structural change"
+quiet | empty new_string
+```
+
+End-to-end via stdin confirms the same for the real hook process:
+
+```
+$ echo '{"tool_name":"Edit","tool_input":{"file_path":"/repo/docs/notes.md","new_string":"Fix typo."}}' \
+    | python3 .agents/hooks/check-codex-before-write.py
+(no output)
+$ ... same path, new_string = 210 x "a" ...
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext":
+ "[Codex Consultation Reminder] Creating new file with meaningful content. You SHOULD consult Codex ..."}}
+```
+
+### agent-router.py — quantification
+
+47-prompt corpus (10 conversational, 16 mechanical asks, 6 genuine design/debug,
+15 ordinary asks that should not route). Result: **24/47 routed (51%)**. Excluding
+the 6 prompts that *should* route, **18 of 41 non-design prompts fired (44%)**.
+
+```
+FIRE [codex] 'option'      <- add a --dry-run option
+FIRE [codex] 'option'      <- add an optional flag to the CLI
+FIRE [codex] 'error'       <- the function returns an error string, wrap it
+FIRE [codex] 'improve'     <- improve the wording of this sentence
+FIRE [codex] 'what if'     <- what if I just delete the file
+FIRE [codex] 'why is'      <- why is the log empty
+FIRE [codex] 'should i'    <- should I use tabs or spaces
+FIRE [codex] 'dependency'  <- add a dependency on requests
+FIRE [codex] 'pattern'     <- explain this regex pattern
+FIRE [codex] 'review'      <- review the changelog wording
+FIRE [codex] 'security'    <- print a security notice in the README
+FIRE [opus-research] 'docs'<- make the docstring better
+FIRE [codex] '依存関係'     <- この関数の依存関係を図にして
+FIRE [codex] '改善'        <- 改善点を1つだけ挙げて
+FIRE [codex] 'パターン'     <- パターンマッチを使って書き直して
+FIRE [codex] '設計'        <- テスト設計は後で
+FIRE [codex] 'セキュリティ' <- セキュリティヘッダーを追加して
+FIRE [codex] '相談'        <- 相談なんだけど昼食は?
+```
+
+`thanks`, `ok`, `lgtm`, `ありがとう`, `了解` and the mechanical asks stay quiet — the
+10→3 length change is largely inert on its own. The damage is from the widened
+keyword list, matched as bare substrings.
+
+### post-implementation-review.py
+
+```
+$ echo '{"tool_name":"Edit","session_id":"revsess1","cwd":"/tmp/fakeproj",
+        "tool_input":{"file_path":"/tmp/fakeproj/a.py","new_string":"x = 1\n"}}' | python3 .agents/hooks/post-implementation-review.py
+(no output)
+$ ... same session, b.py, "y = 2\n" ...
+{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext":
+ "[Code Review Suggestion] 2 files modified in this session. You SHOULD have Codex review ..."}}
+```
+
+Two one-line edits — 2 meaningful lines total — spend the session's single review
+nudge, which the `review_suggested` latch then disables for the rest of the session.
+
+### Regex audit
+
+No catastrophic backtracking: every new pattern is a flat alternation or literal with
+no nested quantifier over an overlapping alternation, so all are linear. Anchoring is
+where the problems are (D1, D4), plus one pattern that silently misses its own target:
+
+```
+$ python3 -c "import re; ..."
+'exit code: 1'  exitpat= False      <- the common formatting is NOT matched
+'exit code 1'   exitpat= True
+'exit status 3' exitpat= True
+'FAILURE'       failpat= False
+'FAILED'        failpat= True
+```
+
+## 4. Defects
+
+### D1 — `post-test-analysis.py:31-49, 87-97`: a green test run is reported as a failure
+
+`FAILURE_PATTERNS` contains the bare tokens `r"ERROR"`, `r"failed"`, `r"Error:"`,
+`r"error:"`, matched with `re.IGNORECASE` and `re.findall`, and the threshold dropped
+to `failure_count >= 1`. Any *word* containing `error` or `failed` anywhere in the
+output — a test name, a filename, a docstring — is now a "failure". Proven live (L1)
+on `8 passed`, and offline on a clean `mypy` run whose only sin is a source file named
+`errors.py`. A debug hint that fires on a green suite is worse than no hint: the
+operator learns to skim past it, and it will be skimmed past on the run that is
+actually red.
+
+Minimal fix — anchor the generic tokens instead of raising the threshold back:
+
+```python
+r"(?m)^(?:FAILED|ERROR)\b",     # replaces bare r"FAILED", r"ERROR", r"FAIL:"
+r"(?m)^E\s",                    # pytest's failure-line prefix
+r"\b\d+\s+failed\b",            # replaces bare r"failed"
+```
+
+and drop the bare `r"Error:"` / `r"error:"` in favour of `r"(?m)^\s*\w*Error:\s"`.
+Keep `MIN_FAILURES_FOR_MULTIPLE`/`>= 1` as they are.
+
+### D2 — `error-to-codex.py:97-112, 195-201`: the new exit-code branch is dead in production
+
+`_exit_code` reads `tool_response["exit_code"]` / `["exitCode"]`. L2 shows that on a
+non-zero exit the hook emits nothing even when the output contains a strong pattern
+that fires identically at exit 0 — so the real payload does not deliver what this
+branch needs, and the branch has never fired. It is green only because the test
+fixture at `tests/test_post_bash_check.py:34-39` constructs the payload itself.
+The PR's headline behaviour ("fire on non-zero exit code") does not exist.
+
+Minimal fix — one of, not both:
+- **Delete** `_exit_code` (lines 97-112) and the `elif exit_code:` branch (lines
+  198-201), restoring `if not errors: return None`; or
+- **Repair**: capture one real failing-Bash PostToolUse payload (temporarily log
+  `json.dumps(data)` from `post-bash-check.py` to a file, run a failing command, read
+  it back), key `_exit_code` off the field that actually exists, and replace the
+  invented fixture with the captured payload. Do not ship the branch until a test
+  built from a captured payload fails without it.
+
+### D3 — `error-to-codex.py:189-201`: the branch contradicts its own rationale
+
+The comment says the case is "the command failed and said nothing quotable about
+why", but the code fires on *any* non-zero exit with ≥5 chars of output, however
+loud. `diff a.txt b.txt` with differences (exit 1, four lines of legitimate output)
+yields "command exited with code 1 - likely a silent failure". If D2 is repaired
+rather than deleted, this fires on every `diff`, `grep -c`, `cmp`, `pgrep` and
+`git diff --exit-code` that produces output.
+
+Minimal fix — make the code match the comment, and exempt exit-status-as-answer
+commands:
+
+```python
+BENIGN_NONZERO_PREFIXES = ("grep", "rg", "diff", "cmp", "test ", "[ ", "pgrep",
+                           "git diff --quiet", "git diff --exit-code")
+...
+elif exit_code and len(tool_output) < QUIET_FAILURE_MAX_CHARS \
+        and not command.strip().startswith(BENIGN_NONZERO_PREFIXES):
+```
+
+### D4 — `error-to-codex.py:45-54`: the new weak patterns co-occur in successful output
+
+`\bdeprecated\b`, `(?:Deprecation|Future)Warning`, `(?:timeout|timed out)`,
+`returned non-zero`, `exit (?:code|status)\s*[1-9]` are added to a list that already
+contains `(?:Cannot|Could not|Unable to)\s`. `MIN_WEAK_SIGNALS` is 2, and warnings
+travel in pairs: verified `pip install` output ("DEPRECATION" + "Could not") and
+`curl` output ("timed out, retrying" + "Unable to") both fire at exit 0, and L3 shows
+a successful `git show` scoring 8. A deprecation warning is by definition not an
+error; putting it in an error-pattern list guarantees false positives on healthy
+builds.
+
+Minimal fix: delete `r"(?:Deprecation|Future)Warning"` and `r"\bdeprecated\b"`
+(lines 50-51) outright — warnings belong in a lint hook, not an error hook — and
+raise `MIN_WEAK_SIGNALS` to 3 (line 58) now that the list has 12 entries instead of 5.
+
+### D5 — `check-codex-before-write.py:123-124`: 200 chars of any edit, described as a file creation
+
+`content` is `tool_input["content"] or tool_input["new_string"]` (line 156), so the
+`NEW_FILE_CONTENT_THRESHOLD` gate applies to **Edit** as well as Write. 200 characters
+is roughly three lines. A 210-character prose edit to `docs/notes.md` fires with the
+message "Creating new file with meaningful content" — it is neither a creation nor a
+file. The hook is wired to `Edit|Write` in `.claude/settings.json`, so this is the
+dominant firing path for the whole hook.
+
+Minimal fix: gate the threshold on the tool that was actually used, and tell the
+truth in the message.
+
+```python
+def should_suggest_codex(file_path, content=None, is_new_file=False):
+    ...
+    if content and is_new_file and len(content) > NEW_FILE_CONTENT_THRESHOLD:
+        return True, "Creating new file with substantial content"
+```
+
+with `is_new_file = data.get("tool_name") == "Write"` at the call site, and
+`NEW_FILE_CONTENT_THRESHOLD` restored to a value that means "substantial" (500).
+
+### D6 — `check-codex-before-write.py:136`: `count("def ")` is a substring count, not a definition count
+
+`content.count("class ") + content.count("def ")` counts the `def ` inside
+`typedef `, `#ifdef `, `#ifndef `, and inside English prose. All three verified
+firing. The `class ` half is additionally near-unreachable, because `"class "` is
+already in `DESIGN_INDICATORS` and returns at line 128 first — so in practice this
+branch counts only `def `-like substrings.
+
+Minimal fix:
+
+```python
+import re
+DEFINITION_RE = re.compile(r"(?m)^\s*(?:async\s+)?def\s+\w|^\s*class\s+\w")
+...
+definition_count = len(DEFINITION_RE.findall(content))
+```
+
+### D7 — `check-codex-before-write.py:47-61`: role words matched against the whole path
+
+`indicator.lower() in filepath_lower` (line 117) with the new entries `cache`,
+`router`, `handler`, `service`, `manager`, `provider`, `signal`, `registry`. Verified:
+`/repo/__pycache__/x.pyc` fires on `cache`; `.agents/hooks/agent-router.py` fires on
+`router`. Every build artefact directory and a large share of ordinary filenames now
+"contain a design decision", and the reason string is confidently wrong.
+
+Minimal fix: compare tokens of the basename, not substrings of the full path, and
+keep concept words (`cache`, `signal`, `retry`) out of the *path* list.
+
+```python
+PATH_ROLE_INDICATORS = {...}   # split from the content indicators
+tokens = set(re.split(r"[^a-z0-9]+", Path(file_path).name.lower()))
+if tokens & PATH_ROLE_INDICATORS: ...
+```
+
+### D8 — `agent-router.py:96-146`: 44% of non-design prompts are routed, and the wording became a mandate
+
+Bare-substring keywords `option`, `pattern`, `improve`, `approach`, `dependency`,
+`security`, `advice`, `error`, `review`, `docs`, and JA `相談`, `改善`, `パターン`,
+`複雑`, `セキュリティ` route 18 of 41 non-design prompts in the corpus above.
+`option` matches `optional`; `docs` matches `docstring`. At the same time lines
+288-294 escalated the wording from "may benefit from / Consider" to "MUST go through
+Codex". A signal that fires on "add a --dry-run option" and calls itself MUST is a
+signal the operator has to start ignoring, which costs exactly the cases the PR
+wanted to catch.
+
+Minimal fix, two parts:
+1. Delete the ambiguous single words from the EN list — `pattern`, `approach`,
+   `improve`, `option`, `alternative`, `dependency`, `security`, `advice` — and from
+   the JA list `パターン`, `改善`, `依存関係`, `セキュリティ`, `相談`, `意見`, `複雑`.
+   Keep the unambiguous multi-word phrases already added (`best practice`,
+   `better way`, `test strategy`, `not sure`, `should i`, `should we`).
+2. Match the EN list on word boundaries so what remains cannot match inside a longer
+   word:
+   `if re.search(rf"\b{re.escape(trigger)}\b", prompt_lower)` (JA has no word
+   boundaries; keep `in` for the JA list).
+
+### D9 — `agent-router.py:262`: the length gate is character-based and still skips short JA triggers
+
+`len(prompt) < 3` skips `設計` (2 characters) — a prompt the comment on lines 260-261
+explicitly claims to want to route — while admitting every 3-character noise prompt.
+The gate now buys nothing and costs a real case.
+
+Minimal fix: delete the gate (lines 260-263). `detect_agent` on an empty or
+one-character prompt matches nothing anyway.
+
+### D10 — `post-implementation-review.py:56-57` vs the one-shot latch at 92-93, 143
+
+`MIN_FILES_FOR_REVIEW = 2` interacts badly with `review_suggested`, which permanently
+disables the hint after the first fire. Verified: two one-line edits (2 meaningful
+lines) trigger it, and the session's only review nudge is then spent — the 400-line
+refactor an hour later gets nothing. The threshold change and the latch were designed
+against each other. *(Unarbitrated: this is the one item where reasonable reviewers
+could disagree about whether 2/50 is simply the intended aggressiveness.)*
+
+Minimal fix — re-arm instead of latching:
+
+```python
+last_files = state.get("suggested_at_files", 0)
+if files_count >= MIN_FILES_FOR_REVIEW and files_count >= last_files * 2:
+    ...
+    state["suggested_at_files"] = files_count
+```
+
+(keeping `review_suggested` only as a within-threshold debounce), or leave the latch
+and restore `MIN_FILES_FOR_REVIEW = 3`.
+
+### D11 — test coverage does not cover the behaviour that changed
+
+`tests/test_post_bash_check.py` is the only test touching these hooks. It has no
+negative case for any lowered threshold, and its `bash_hook_input` helper
+(lines 34-39) asserts a payload contract that L2 shows production does not provide.
+`agent-router.py`, `check-codex-before-write.py` and `post-implementation-review.py`
+have no tests at all, despite all three changing behaviour in this merge. Under
+`.agents/rules/testing.md` (Test Case Coverage: normal / boundary / error cases) a
+threshold change is precisely a boundary change and should arrive with the boundary
+tests.
+
+Minimal fix: add to `tests/test_post_bash_check.py`
+`test_green_pytest_output_produces_no_hint` (the `8 passed` + `..._error_hint PASSED`
+output) and `test_benign_nonzero_exit_produces_no_hint` (`diff` with differences),
+plus a new `tests/test_hook_thresholds.py` covering `should_suggest_codex`,
+`detect_agent` and `should_suggest_review` with one fire and one no-fire case each.
+
+## 5. What is NOT wrong
+
+- All five files compile; `.agents/check.sh` is 8/8; the suite is 967 green.
+- No catastrophic backtracking in any new or existing pattern (all flat alternations).
+- `^error\[\w+\]` and the errno alternation `\b(?:ECONNREFUSED|...)\b` are correctly
+  anchored and escaped, and the strong-pattern additions
+  (`OutOfMemoryError`, `undefined reference to`, `too many open files`) are specific
+  enough to belong in the strong list.
+- `_exit_code`'s `isinstance(value, bool): continue` guard is correct (`bool` is an
+  `int` subclass, and `True` would otherwise read as exit 1).
+- Keeping the noise-prone patterns as *weak* signals rather than promoting them, as
+  the merge commit message claims, is the right call — the defect is that 12 weak
+  signals with a threshold of 2 is no longer weak.
+- `post-test-analysis`'s dedup against `error-to-codex` in `post-bash-check.py` still
+  works (verified by the existing green test).
+
+## 6. Files touched by this review
+
+None. `.agents/hooks/` and `tests/` are unmodified; `git status --porcelain` shows
+only this report and the parallel agent's checkpointing report. Artefacts written:
+this file, and under `.agents/logs/codex/` the prompt, empty response and error log
+of the failed consult.

--- a/.agents/docs/reviews/pr35-hooks-fix-evidence-2026-09-03.md
+++ b/.agents/docs/reviews/pr35-hooks-fix-evidence-2026-09-03.md
@@ -1,0 +1,139 @@
+# PR #35 hook fixes — executed evidence (2026-09-03)
+
+Companion to `.agents/docs/reviews/pr35-hooks-codex-review-2026-09-03.md`.
+Branch `claude/resolve-pr-conflicts-agkoey`; merge `9d93caf` is not reverted.
+
+**Codex was not consulted**: the egress proxy answers 403 to CONNECT for
+`api.openai.com`, so every judgment call below rests on executed evidence only.
+Explicitly unarbitrated: the D2 delete-vs-repair choice, the D10 doubling rule,
+and the decision to match router triggers with an optional plural `s`.
+
+## D2 — the captured real PostToolUse payload
+
+`post-bash-check.py` was temporarily patched to append its raw stdin to
+`/tmp/hookpayload-capture.jsonl`, several Bash commands were run in a live
+Claude Code session, and the patch was reverted (`git diff` for that file is
+empty). Two findings, both fatal to the exit-code branch:
+
+1. `tool_response` carries **no exit status under any spelling**. Every captured
+   payload has exactly these keys:
+
+```
+top-level:      agent_id, agent_type, cwd, duration_ms, effort, hook_event_name,
+                permission_mode, prompt_id, scratchpad_dir, session_id,
+                tool_input, tool_name, tool_response, tool_use_id, transcript_path
+tool_response:  interrupted, isImage, noOutputExpected, stderr, stdout
+```
+
+Representative captured object (a successful `cp`+patch command):
+
+```json
+{"session_id":"c862d471-...","cwd":"/home/user/claude-code-orchestra",
+ "hook_event_name":"PostToolUse","tool_name":"Bash",
+ "tool_input":{"command":"cp .agents/hooks/post-bash-check.py ... "},
+ "tool_response":{"stdout":"patched","stderr":"","interrupted":false,
+                  "isImage":false,"noOutputExpected":false},
+ "tool_use_id":"toolu_01P9S4GwpLVnAKBDG5ueyG63","duration_ms":64}
+```
+
+2. **A failing Bash command does not reach the hook at all.** Four genuinely
+   failing commands were run while the capture patch was live —
+   `printf 'alpha...'; exit 7`, `printf 'Traceback...'; exit 1`,
+   `wc -l ...; false`, `printf 'CAPTURE_FAILING_CASE'; exit 3` — and **none**
+   produced a capture line, while every exit-0 command in the same window did.
+   This independently reproduces the review's L2 observation.
+
+**Decision: delete, not repair.** There is no field to key off, and even a
+correctly-keyed branch would be unreachable because the hook is not invoked on
+failure. `_exit_code()` and the `elif exit_code:` branch are removed;
+`build_context` restores `if not errors: return None`.
+
+The fixture `bash_hook_input(..., exit_code=...)` in
+`tests/test_post_bash_check.py` is **kept**, because `log-cli-tools.py:201,222,260`
+also reads `tool_response["exit_code"]` and four existing tests assert its
+`success` field — deleting the fixture parameter would delete those tests, which
+the brief forbids. Its docstring now records the captured contract.
+
+**Flagged, out of scope**: `log-cli-tools.py` derives `success` from the same
+absent `exit_code`, so its `success` is effectively always `True` for bare
+`codex exec` calls (wrapper calls degrade gracefully via the JSON `ok` field).
+That hook is not in this task's scope and was not changed.
+
+## Reproductions — now quiet
+
+```
+R1 green pytest -v  -> post-test-analysis: None
+R1 green pytest -v  -> error-to-codex   : None
+R2 diff exit1 loud  -> error-to-codex   : None
+```
+
+## Reproductions — still firing (the fix does not silence real failures)
+
+```
+R4 red pytest       -> [Codex Debug Suggestion] Multiple failures detected (5 issues). ...
+R5 real traceback   -> [Error Detected] 2 error pattern(s) found in command output. ...
+```
+
+## agent-router corpus
+
+Of the 18 non-design prompts the review recorded as firing, 6 still fire:
+
+```
+('codex', 'error')    <- the function returns an error string, wrap it
+('codex', 'what if')  <- what if I just delete the file
+('codex', 'why is')   <- why is the log empty
+('codex', 'should i') <- should I use tabs or spaces
+('codex', 'review')   <- review the changelog wording
+('codex', '設計')      <- テスト設計は後で
+```
+
+All six come from triggers the brief told me to **keep**: `what if`, `why is`,
+`should i` are on the keep list, and `error`, `review`, `設計` predate PR #35.
+The 12 that stopped firing are exactly the removed ambiguous words.
+
+Still routing correctly:
+
+```
+('codex', '設計')                 <- 設計                (the D9 case the length gate skipped)
+('codex', 'design')             <- how should we design this module?
+('codex', 'why does')           <- why does this fail?
+('opus-research', 'research')   <- research the latest version
+('codex-plugin', 'review this') <- review this code
+('fable', 'stuck')              <- I am stuck on the design
+```
+
+## check-codex-before-write end-to-end (stdin)
+
+```
+Edit, /repo/docs/notes.md, 210 chars      -> (no output)
+Edit, /repo/__pycache__/x.pyc             -> (no output)
+Write, /repo/tools/helper.py, 630 chars   -> [Codex Consultation Reminder] Creating new file with substantial content ...
+```
+
+## Acceptance checks
+
+```
+OK agent-router.py / check-codex-before-write.py / error-to-codex.py /
+   post-test-analysis.py / post-implementation-review.py        (py_compile)
+
+bash .agents/check.sh   -> Results: 8 passed, 0 failed
+
+python3 .agents/skills/_shared/run_tests.py --expect pass --target tests/ --label pr35-hookfix
+{"expected":"passed","observed":"passed","runner":"uv","exit_code":0,
+ "summary":"994 passed in 88.66s (0:01:28)","failed_tests":[],"ok":true}
+```
+
+## Residual risks
+
+- `post-test-analysis.FAILURE_PATTERNS` is now matched **case-sensitively**
+  (`re.findall(pattern, output)` without `re.IGNORECASE`). A runner that prints
+  a lowercase `failed:` verdict at line start is no longer detected; the
+  anchored `^(?:FAILED|ERROR)\b`, `^E\s`, `^FAIL\b`, `\b\d+\s+failed\b` and
+  `^\s*\w*(?:Error|Exception):\s` cover pytest, cargo, go and node.
+- `post-implementation-review` re-arm doubles from the last firing size
+  (2 -> 4 -> 8 files, 50 -> 100 -> 200 lines). A state file written by the old
+  code lacks `suggested_at_*`, so the hint may fire once more in a session that
+  spans the upgrade. Harmless.
+- `agent-router` EN matching adds an optional plural `s` (`\berrors?\b`) so the
+  word-boundary change does not silently drop plural forms that the old
+  substring match caught.

--- a/.agents/hooks/agent-router.py
+++ b/.agents/hooks/agent-router.py
@@ -12,6 +12,7 @@ Multimodal files (PDF/video/audio/image) are handled directly by Claude (Opus 4.
 """
 
 import json
+import re
 import sys
 
 # Triggers for Fable advisor (rare escalation: arbitration, stuck, final review)
@@ -73,24 +74,21 @@ CODEX_TRIGGERS = {
         "最適化",
         # Proactive triggers: uncertainty and quality questions are exactly
         # where a Codex consult is cheaper than the rework it prevents.
+        # Single words that name a topic rather than a request for judgement
+        # ("パターン", "改善", "セキュリティ", "依存関係", "相談", "意見",
+        # "複雑") are deliberately absent: they fired on ordinary asks such as
+        # "セキュリティヘッダーを追加して" and even "相談なんだけど昼食は?".
         "どうすべき",
         "良い方法",
         "ベストプラクティス",
-        "パターン",
-        "改善",
         "パフォーマンス",
-        "セキュリティ",
         "テスト戦略",
         "テスト設計",
-        "依存関係",
         "循環",
-        "複雑",
         "わからない",
         "迷って",
         "不安",
         "自信がない",
-        "相談",
-        "意見",
         "アドバイス",
     ],
     "en": [
@@ -120,28 +118,24 @@ CODEX_TRIGGERS = {
         "deeply",
         "optimize",
         "performance",
-        # Proactive triggers (mirror of the Japanese list above).
+        # Proactive triggers (mirror of the Japanese list above). Only
+        # multi-word phrases and unambiguous words survive: bare "option",
+        # "pattern", "approach", "improve", "alternative", "dependency",
+        # "security" and "advice" routed 44% of non-design prompts, including
+        # "add a --dry-run option" and "improve the wording of this sentence".
         "best practice",
-        "pattern",
-        "approach",
-        "improve",
-        "security",
         "test strategy",
         "test design",
-        "dependency",
         "circular",
         "not sure",
         "unsure",
         "uncertain",
-        "advice",
         "should i",
         "should we",
         "what if",
         "why does",
         "why is",
         "how come",
-        "alternative",
-        "option",
         "better way",
     ],
 }
@@ -212,6 +206,20 @@ CODEX_PLUGIN_TRIGGERS = {
 }
 
 
+def matches_trigger(trigger: str, prompt_lower: str, lang: str) -> bool:
+    """Check one trigger against the lowercased prompt.
+
+    English triggers are matched on word boundaries (with an optional plural
+    "s"), so "option" can no longer match "optional" and "docs" can no longer
+    match "docstring". Japanese has no word boundaries, so those triggers stay
+    substring matches — which is why the ambiguous single words were removed
+    from the Japanese lists instead.
+    """
+    if lang != "en":
+        return trigger in prompt_lower
+    return re.search(rf"\b{re.escape(trigger)}s?\b", prompt_lower) is not None
+
+
 def detect_agent(prompt: str) -> tuple[str | None, str]:
     """Detect which agent should handle this prompt.
 
@@ -222,9 +230,9 @@ def detect_agent(prompt: str) -> tuple[str | None, str]:
     # Fable triggers (rare escalation: arbitration, stuck, final review)
     # Checked FIRST — narrow, high-specificity triggers that must not be
     # swallowed by the broader Codex keywords.
-    for triggers in FABLE_TRIGGERS.values():
+    for lang, triggers in FABLE_TRIGGERS.items():
         for trigger in triggers:
-            if trigger in prompt_lower:
+            if matches_trigger(trigger, prompt_lower, lang):
                 return "fable", trigger
 
     # Codex Plugin triggers (review, rescue, delegation)
@@ -232,21 +240,21 @@ def detect_agent(prompt: str) -> tuple[str | None, str]:
     # phrases (e.g. "コードレビュー", "review this") that the bare
     # CODEX_TRIGGERS substrings (e.g. "レビュー", "review") would
     # otherwise shadow.
-    for triggers in CODEX_PLUGIN_TRIGGERS.values():
+    for lang, triggers in CODEX_PLUGIN_TRIGGERS.items():
         for trigger in triggers:
-            if trigger in prompt_lower:
+            if matches_trigger(trigger, prompt_lower, lang):
                 return "codex-plugin", trigger
 
     # Codex triggers (planning, design, debug, complex code)
-    for triggers in CODEX_TRIGGERS.values():
+    for lang, triggers in CODEX_TRIGGERS.items():
         for trigger in triggers:
-            if trigger in prompt_lower:
+            if matches_trigger(trigger, prompt_lower, lang):
                 return "codex", trigger
 
     # Opus research triggers (codebase analysis + external research)
-    for triggers in OPUS_RESEARCH_TRIGGERS.values():
+    for lang, triggers in OPUS_RESEARCH_TRIGGERS.items():
         for trigger in triggers:
-            if trigger in prompt_lower:
+            if matches_trigger(trigger, prompt_lower, lang):
                 return "opus-research", trigger
 
     return None, ""
@@ -257,11 +265,10 @@ def main():
         data = json.load(sys.stdin)
         prompt = data.get("prompt", "")
 
-        # Skip only trivially short prompts. Terse but loaded asks
-        # ("debug this", "なぜ?") are exactly the ones worth routing.
-        if len(prompt) < 3:
-            sys.exit(0)
-
+        # No length gate: it was character-based, so it skipped "設計" (two
+        # characters) — the exact terse-but-loaded ask it claimed to rescue —
+        # while admitting every three-character noise prompt. detect_agent
+        # matches nothing on an empty or one-character prompt anyway.
         agent, trigger = detect_agent(prompt)
 
         if agent == "fable":

--- a/.agents/hooks/check-codex-before-write.py
+++ b/.agents/hooks/check-codex-before-write.py
@@ -7,7 +7,9 @@ for design decisions, complex implementations, or architectural changes.
 """
 
 import json
+import re
 import sys
+from pathlib import Path
 
 # Input validation constants
 MAX_PATH_LENGTH = 4096
@@ -26,24 +28,22 @@ def validate_input(file_path: str, content: str) -> bool:
     return True
 
 
-# Patterns that suggest design/architecture decisions
-DESIGN_INDICATORS = [
-    # File patterns
-    "DESIGN.md",
-    "ARCHITECTURE.md",
+# Structural roles that make a *file* a seam other code depends on. Matched
+# against the name tokens of the file and of its immediate directory, never as
+# substrings of the whole path: "cache" as a substring made every
+# __pycache__/ artefact "a design decision".
+PATH_ROLE_INDICATORS = {
     "architecture",
     "design",
     "schema",
     "model",
+    "models",
     "interface",
     "abstract",
-    "base_",
-    "core/",
-    "/core/",
+    "base",
+    "core",
     "config",
     "settings",
-    # Structural / architectural roles: a file named for one of these is
-    # almost always a seam other code depends on.
     "middleware",
     "router",
     "handler",
@@ -59,7 +59,12 @@ DESIGN_INDICATORS = [
     "provider",
     "registry",
     "pipeline",
-    # Code patterns in content
+}
+
+# Patterns in the written *content* that suggest design/architecture decisions.
+# Concept words ("cache", "signal", "retry") belong here and not in the path
+# list: they describe what the code does, not what the file is named.
+DESIGN_INDICATORS = [
     "class ",
     "interface ",
     "abstract class",
@@ -81,12 +86,23 @@ DESIGN_INDICATORS = [
     "singleton",
 ]
 
+# A real function/class definition, as opposed to the substring "def " inside
+# "typedef", "#ifdef", or English prose — all three of which the previous
+# content.count("def ") counted as definitions.
+DEFINITION_RE = re.compile(r"(?m)^\s*(?:async\s+)?def\s+\w|^\s*class\s+\w")
+
+# Word-ish tokens of a path component.
+TOKEN_SPLIT_RE = re.compile(r"[^a-z0-9]+")
+
 # Number of function/class definitions in one payload that makes it
 # structural rather than a local edit.
 MIN_DEFINITIONS_FOR_REVIEW = 2
 
 # Content-size thresholds (characters) above which a write is worth a look.
-NEW_FILE_CONTENT_THRESHOLD = 200
+# The new-file threshold applies only to Write (an actual creation); 200
+# characters of an Edit is roughly three lines of prose, and announcing that
+# as "creating a new file" was both wrong and the hook's dominant firing path.
+NEW_FILE_CONTENT_THRESHOLD = 500
 SRC_FILE_CONTENT_THRESHOLD = 50
 
 # Files that are typically simple edits (skip suggestion)
@@ -101,10 +117,23 @@ SIMPLE_EDIT_PATTERNS = [
 ]
 
 
+def path_role_tokens(file_path: str) -> set[str]:
+    """Name tokens of the file and of the directory that contains it."""
+    path = Path(file_path)
+    tokens: set[str] = set()
+    for part in (path.name, path.parent.name):
+        tokens.update(t for t in TOKEN_SPLIT_RE.split(part.lower()) if t)
+    return tokens
+
+
 def should_suggest_codex(
-    file_path: str, content: str | None = None
+    file_path: str, content: str | None = None, is_new_file: bool = False
 ) -> tuple[bool, str]:
-    """Determine if Codex consultation should be suggested."""
+    """Determine if Codex consultation should be suggested.
+
+    ``is_new_file`` must be True only for a Write (a whole-file creation or
+    replacement); an Edit patches an existing file, however long the patch.
+    """
     filepath_lower = file_path.lower()
 
     # Skip simple edits
@@ -113,15 +142,18 @@ def should_suggest_codex(
             return False, ""
 
     # Check file path for design indicators
-    for indicator in DESIGN_INDICATORS:
-        if indicator.lower() in filepath_lower:
-            return True, f"File path contains '{indicator}' - likely a design decision"
+    role_matches = sorted(path_role_tokens(file_path) & PATH_ROLE_INDICATORS)
+    if role_matches:
+        return (
+            True,
+            f"File is named for the role '{role_matches[0]}' - likely a design decision",
+        )
 
     # Check content if available
     if content:
-        # New file with meaningful content
-        if len(content) > NEW_FILE_CONTENT_THRESHOLD:
-            return True, "Creating new file with meaningful content"
+        # A whole new file of substantial size.
+        if is_new_file and len(content) > NEW_FILE_CONTENT_THRESHOLD:
+            return True, "Creating new file with substantial content"
 
         # Check for design patterns in content
         for indicator in DESIGN_INDICATORS:
@@ -133,7 +165,7 @@ def should_suggest_codex(
 
         # Several definitions in one payload means structure is being decided,
         # not a single line being fixed.
-        definition_count = content.count("class ") + content.count("def ")
+        definition_count = len(DEFINITION_RE.findall(content))
         if definition_count >= MIN_DEFINITIONS_FOR_REVIEW:
             return (
                 True,
@@ -159,7 +191,9 @@ def main():
         if not validate_input(file_path, content):
             sys.exit(0)
 
-        should_suggest, reason = should_suggest_codex(file_path, content)
+        # Only a Write creates or replaces a whole file; an Edit is a patch.
+        is_new_file = data.get("tool_name") == "Write"
+        should_suggest, reason = should_suggest_codex(file_path, content, is_new_file)
 
         if should_suggest:
             # Return additional context to Claude

--- a/.agents/hooks/error-to-codex.py
+++ b/.agents/hooks/error-to-codex.py
@@ -43,19 +43,21 @@ WEAK_ERROR_PATTERNS = [
     r"(?:Cannot|Could not|Unable to)\s",
     r"cargo error",
     # Individually ambiguous: a passing run may legitimately print "timed out
-    # (retrying)" or a deprecation notice. Only a second signal makes them a
-    # reason to stop and diagnose.
+    # (retrying)". Only further signals make them a reason to stop and diagnose.
+    # Deprecation notices are deliberately absent: a warning is by definition
+    # not an error, and pip/curl output pairs them with "Could not"/"Unable to"
+    # often enough that two-of-a-kind fired on healthy builds.
     r"(?:timeout|timed out)",
     r"(?:DNS|name) resolution",
-    r"(?:Deprecation|Future)Warning",
-    r"\bdeprecated\b",
     r"resource temporarily unavailable",
     r"returned non-zero",
     r"exit (?:code|status)\s*[1-9]",
 ]
 
 # Minimum number of weak signals required when no strong signal is present.
-MIN_WEAK_SIGNALS = 2
+# Ten weak patterns co-occur too easily for a threshold of two: a successful
+# `git show` of this repository scored eight.
+MIN_WEAK_SIGNALS = 3
 
 # Commands to ignore (not useful to debug)
 IGNORE_COMMANDS = [
@@ -92,24 +94,6 @@ SKIP_COMMANDS = [
 # Terse failures ("Error: failed") are still failures, so the floor only has
 # to exclude effectively empty output.
 MIN_OUTPUT_LENGTH = 5
-
-
-def _exit_code(tool_response: dict) -> int:
-    """Read the command's exit status from either spelling, defaulting to 0.
-
-    log-cli-tools.py reads ``exit_code``; some payload versions use the
-    camelCase ``exitCode``. A non-integer value is treated as "unknown", which
-    means "do not claim a failure".
-    """
-    for key in ("exit_code", "exitCode"):
-        value = tool_response.get(key)
-        if isinstance(value, bool):
-            continue
-        if isinstance(value, int):
-            return value
-        if isinstance(value, str) and value.strip().lstrip("-").isdigit():
-            return int(value)
-    return 0
 
 
 def should_ignore_command(command: str) -> bool:
@@ -187,18 +171,10 @@ def build_context(data: dict) -> str | None:
         return None
 
     errors = detect_errors(tool_output)
-
-    # A non-zero exit with no recognised pattern is the most dangerous case,
-    # not the safest one: the command failed and said nothing quotable about
-    # why. Checked after the ignore filters so known-benign commands and
-    # trivial outputs still stay silent.
-    exit_code = _exit_code(tool_response)
-    if errors:
-        reason = f"{len(errors)} error pattern(s) found in command output"
-    elif exit_code:
-        reason = f"command exited with code {exit_code} - likely a silent failure"
-    else:
+    if not errors:
         return None
+
+    reason = f"{len(errors)} error pattern(s) found in command output"
 
     return (
         f"[Error Detected] {reason}. "

--- a/.agents/hooks/post-implementation-review.py
+++ b/.agents/hooks/post-implementation-review.py
@@ -38,7 +38,7 @@ def get_state_file_path(data: dict) -> str:
 
     Namespacing prevents concurrent Claude Code sessions (same machine,
     different projects, or the same project) from clobbering each other's
-    counters and the review_suggested flag.
+    counters and last-suggested markers.
     """
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or data.get("cwd") or os.getcwd()
     project_hash = hashlib.sha256(os.path.abspath(project_dir).encode()).hexdigest()[
@@ -66,7 +66,12 @@ def load_state(state_file: str) -> dict:
                 return json.load(f)
     except Exception:
         pass
-    return {"files_changed": [], "total_lines": 0, "review_suggested": False}
+    return {
+        "files_changed": [],
+        "total_lines": 0,
+        "suggested_at_files": 0,
+        "suggested_at_lines": 0,
+    }
 
 
 def save_state(state: dict, state_file: str):
@@ -89,17 +94,23 @@ def count_lines(content: str) -> int:
 
 
 def should_suggest_review(state: dict) -> tuple[bool, str]:
-    """Check if we should suggest a code review."""
-    if state.get("review_suggested"):
-        return False, ""
+    """Check if we should suggest a code review.
 
+    Re-arms instead of latching. A one-shot latch combined with a threshold of
+    two files meant that two one-line edits spent the session's only review
+    nudge and the 400-line refactor an hour later got none. Instead the hint
+    debounces until the session has doubled in size since it last fired, so
+    each suggestion covers materially more work than the previous one.
+    """
     files_count = len(state.get("files_changed", []))
     total_lines = state.get("total_lines", 0)
+    suggested_at_files = state.get("suggested_at_files", 0)
+    suggested_at_lines = state.get("suggested_at_lines", 0)
 
-    if files_count >= MIN_FILES_FOR_REVIEW:
+    if files_count >= max(MIN_FILES_FOR_REVIEW, suggested_at_files * 2):
         return True, f"{files_count} files modified"
 
-    if total_lines >= MIN_LINES_FOR_REVIEW:
+    if total_lines >= max(MIN_LINES_FOR_REVIEW, suggested_at_lines * 2):
         return True, f"{total_lines}+ lines written"
 
     return False, ""
@@ -141,7 +152,11 @@ def main():
         should_review, reason = should_suggest_review(state)
 
         if should_review:
-            state["review_suggested"] = True
+            # Record the size at which the hint fired; the next one waits for
+            # double that, on both axes, so firing on files does not leave the
+            # line counter free to fire again on the very next edit.
+            state["suggested_at_files"] = len(state["files_changed"])
+            state["suggested_at_lines"] = state["total_lines"]
             save_state(state, state_file)
 
             output = {

--- a/.agents/hooks/post-test-analysis.py
+++ b/.agents/hooks/post-test-analysis.py
@@ -27,25 +27,35 @@ TEST_BUILD_COMMANDS = [
     "make build",
 ]
 
-# Patterns indicating failures that need debugging
+# Patterns indicating failures that need debugging.
+#
+# Every pattern is anchored or quantified so that it can only match a runner's
+# *verdict*, never a test name, a file name, or prose. Bare tokens ("ERROR",
+# "failed", "Error:") matched a green `pytest -v` run whose test names merely
+# contained the word "error", so the hint fired on 8 passed, 0 failed.
+# Matched case-sensitively for the same reason: "error" in an identifier is not
+# an error, "ERROR" at the start of a line is.
 FAILURE_PATTERNS = [
-    r"FAILED",
-    r"ERROR",
-    r"error\[",
-    r"Error:",
-    r"failed",
-    r"error:",
-    r"AssertionError",
-    r"TypeError",
-    r"ValueError",
-    r"AttributeError",
-    r"ImportError",
-    r"ModuleNotFoundError",
-    r"SyntaxError",
-    r"Exception",
-    r"Traceback",
-    r"panic:",
-    r"FAIL:",
+    # Runner verdict lines: pytest "FAILED test_x", "ERROR test_x".
+    r"(?m)^(?:FAILED|ERROR)\b",
+    # pytest's failure-detail prefix ("E   assert 1 == 2").
+    r"(?m)^E\s",
+    # Summary counts: "1 failed, 2 passed".
+    r"\b\d+\s+failed\b",
+    # An exception header at the start of a line, qualified or not:
+    # "AssertionError: ...", "django.db.Error: ...", "Exception: ...".
+    r"(?m)^\s*(?:\w+\.)*\w*(?:Error|Exception):\s",
+    # rustc / cargo diagnostics.
+    r"(?m)^error\[\w+\]",
+    # Go panics and gotest/ctest verdict lines.
+    r"(?m)^panic:",
+    r"(?m)^FAIL\b",
+    # Python traceback header (parenthesised, so it cannot match a test name).
+    r"Traceback \(most recent call last\):",
+    # Named exception types as whole words; case-sensitive, so the lowercase
+    # forms that appear inside identifiers do not match.
+    r"\b(?:AssertionError|TypeError|ValueError|AttributeError|ImportError|"
+    r"ModuleNotFoundError|SyntaxError)\b",
 ]
 
 # Failure count at which the output is reported as a multi-failure run.
@@ -76,7 +86,7 @@ def has_complex_failure(output: str) -> tuple[bool, str]:
     failure_count = 0
     matched_patterns = []
     for pattern in FAILURE_PATTERNS:
-        matches = re.findall(pattern, output, re.IGNORECASE)
+        matches = re.findall(pattern, output)
         if matches:
             failure_count += len(matches)
             matched_patterns.append(pattern)

--- a/.agents/rules/codex-delegation.md
+++ b/.agents/rules/codex-delegation.md
@@ -67,14 +67,17 @@ Do NOT delegate to Codex when:
 ## Hook-Detected Triggers
 
 Repository hooks surface these automatically; treat each hint as a prompt to
-route, not as noise to dismiss.
+route, not as noise to dismiss. Confirm the command actually failed before
+routing to `codex-debugger`: the Bash hook only ever sees successful commands
+(the runtime does not invoke it for a failing one) and matches on output text,
+so it fires on read-only commands that merely display error-shaped output.
 
 | Situation | Hook | Suggested route |
 |-----------|------|-----------------|
 | Prompt contains design / debug / uncertainty keywords | `agent-router.py` | Codex, or `general-purpose-opus` |
 | Write/Edit touching design-related or structural code | `check-codex-before-write.py` | Codex design review |
 | Test or build failure | `post-test-analysis.py` | `codex-debugger` |
-| Any Bash error or non-zero exit | `error-to-codex.py` | `codex-debugger` |
+| Bash output matches error patterns | `error-to-codex.py` | `codex-debugger` |
 | Plan created | `check-codex-after-plan.py` | Codex plan validation |
 | 2+ files or 50+ lines changed this session | `post-implementation-review.py` | Codex code review |
 

--- a/.agents/skills/catchup/SKILL.md
+++ b/.agents/skills/catchup/SKILL.md
@@ -79,7 +79,8 @@ Top-level JSON keys:
   `libraries`.
 - `env` — `manifests`, `scripts` (from `pyproject.toml`), `commands`
   (each with the `source` file it was quoted from), `errors`.
-- `checkpoints` — newest 5 (file + first heading).
+- `checkpoints` — newest 5 (file + `first_line`: the frontmatter `summary`,
+  else its `slug`, else the first non-empty body line — never the `---` fence).
 - `agent_teams` — `sessions[{name, members, tasks_total, tasks_completed}]`
   and in-repo `work_logs`.
 - `cli_tools` — recent consultations for **every** tool, each tagged with

--- a/.agents/skills/catchup/collect_repo_state.py
+++ b/.agents/skills/catchup/collect_repo_state.py
@@ -49,6 +49,8 @@ MAX_KEY_DECISIONS = 10
 MAX_ENV_COMMANDS = 20
 
 CHECKPOINT_STEM_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{6}$")
+FRONTMATTER_FENCE = "---"
+FRONTMATTER_NAME_KEYS = ("summary", "slug")
 DESIGN_PLACEHOLDER_HEADING_MARKER = "Background & Purpose"
 HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 KEY_DECISIONS_HEADING = "## Key Decisions"
@@ -146,6 +148,68 @@ def file_info(path: Path) -> dict:
                 "error": None,
             }
     return {"present": True, "first_line": "", "error": None}
+
+
+def _first_meaningful_line(text: str) -> str:
+    """A checkpoint's own name for itself, looking past its frontmatter block.
+
+    Checkpoints written since the fast-retrieval feature open with a ``---``
+    block, so their first non-empty line is the fence itself, which names no
+    session. The block carries a better answer than any heading (``summary``,
+    else ``slug``); when it carries neither, or when the block is unterminated
+    or absent, fall back to the first non-empty line of the body.
+
+    Deliberately a local reader rather than an import of the checkpointing
+    skill's ``parse_frontmatter``: the two skills stay decoupled, and this only
+    needs two keys out of a block it never writes.
+    """
+    lines = text.splitlines()
+    body_start = 0
+    if lines and lines[0].strip() == FRONTMATTER_FENCE:
+        closing = next(
+            (
+                index
+                for index in range(1, len(lines))
+                if lines[index].strip() == FRONTMATTER_FENCE
+            ),
+            None,
+        )
+        if closing is not None:
+            fields: dict[str, str] = {}
+            for line in lines[1:closing]:
+                key, separator, value = line.partition(":")
+                if separator:
+                    fields[key.strip()] = _unquote_frontmatter_value(value.strip())
+            for key in FRONTMATTER_NAME_KEYS:
+                value = fields.get(key, "").strip()
+                if value:
+                    return value
+            body_start = closing + 1
+    for line in lines[body_start:]:
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def _unquote_frontmatter_value(value: str) -> str:
+    """Undo the quoting build_frontmatter applies to a string scalar."""
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return value[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+    return value
+
+
+def checkpoint_info(path: Path) -> dict:
+    """file_info for a checkpoint, whose first line is a frontmatter fence."""
+    text, error = read_text(path)
+    if error is not None:
+        return {"present": True, "first_line": None, "error": error}
+    if text is None:
+        return {"present": False, "first_line": None, "error": None}
+    return {
+        "present": True,
+        "first_line": _first_meaningful_line(text)[:FIRST_LINE_LIMIT],
+        "error": None,
+    }
 
 
 # --- git ---------------------------------------------------------------------
@@ -557,7 +621,12 @@ def collect_rules(root: Path) -> dict:
 
 
 def collect_checkpoints(root: Path) -> dict:
-    """Summarize the newest checkpoints (filename + first heading line)."""
+    """Summarize the newest checkpoints (filename + the session's own name).
+
+    ``first_line`` is the frontmatter ``summary`` (else ``slug``) when the
+    checkpoint has a frontmatter block, and the first non-empty body line
+    otherwise — never the ``---`` fence.
+    """
     checkpoints_dir = root / ".agents" / "checkpoints"
     if not checkpoints_dir.is_dir():
         return {"present": False, "items": []}
@@ -569,7 +638,7 @@ def collect_checkpoints(root: Path) -> dict:
     return {
         "present": True,
         "items": [
-            {"file": path.name, **file_info(path)}
+            {"file": path.name, **checkpoint_info(path)}
             for path in files[:CHECKPOINT_PREVIEW]
         ],
     }

--- a/.agents/skills/checkpointing/checkpoint.py
+++ b/.agents/skills/checkpointing/checkpoint.py
@@ -89,6 +89,8 @@ SLUG_MAX_LENGTH = 40
 SLUG_MAX_KEYWORDS = 3
 DEFAULT_SLUG = "session"
 HEADLINE_COMMITS = 3
+# Everything outside this set is replaced in a tag; see _sanitize_tag.
+TAG_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._/-]+")
 
 # Conventional-commit prefix -> the tag/slug word used for it.
 COMMIT_TYPE_CATEGORIES = {
@@ -593,8 +595,16 @@ def derive_slug(collected: Collected, label: str | None = None) -> str:
 
 
 def _sanitize_tag(tag: str) -> str:
-    """Strip characters that would break the frontmatter list or index table."""
-    return re.sub(r"[\[\]|,\s]+", "-", tag.strip()).strip("-")
+    """Reduce a tag to characters that are inert in YAML and in a table cell.
+
+    An allow-list rather than a deny-list: tags are built from directory names
+    and Agent Teams session names, so the set of characters that can arrive is
+    open-ended, while the set that is safe inside a ``tags: [a, b]`` flow
+    sequence is small and known. ``#`` would open a comment and leave the
+    sequence unclosed, ``&``/``*`` become an anchor and an undefined alias,
+    and ``:``/``{``/``}`` silently turn the entry into a mapping.
+    """
+    return re.sub(TAG_UNSAFE_RE, "-", tag.strip()).strip("-")
 
 
 def derive_tags(collected: Collected) -> list[str]:
@@ -694,15 +704,26 @@ def parse_frontmatter(text: str) -> dict[str, str]:
     Deliberately not a YAML parser: the block is written by build_frontmatter
     above, so a line-oriented reader is enough and keeps the script
     dependency-free. A checkpoint without frontmatter (any file written before
-    this feature existed) yields an empty mapping rather than an error.
+    this feature existed) yields an empty mapping rather than an error, and so
+    does one whose block is never closed: without a closing fence there is no
+    way to tell a field from a body line that happens to contain a colon, and
+    promoting the body into the index is worse than showing no metadata.
     """
     lines = text.splitlines()
     if not lines or lines[0].strip() != FRONTMATTER_FENCE:
         return {}
+    closing = next(
+        (
+            index
+            for index in range(1, len(lines))
+            if lines[index].strip() == FRONTMATTER_FENCE
+        ),
+        None,
+    )
+    if closing is None:
+        return {}
     fields: dict[str, str] = {}
-    for line in lines[1:]:
-        if line.strip() == FRONTMATTER_FENCE:
-            break
+    for line in lines[1:closing]:
         key, separator, value = line.partition(":")
         if not separator:
             continue
@@ -720,7 +741,7 @@ def _escape_table_cell(value: str) -> str:
 
 def _index_row(stem: str, fields: dict[str, str]) -> str:
     """Render one INDEX.md row from a checkpoint's frontmatter."""
-    slug = fields.get("slug") or stem
+    slug = _sanitize_tag(fields.get("slug", "")) or stem
     branch = fields.get("branch", "-") or "-"
     tags = [tag.strip() for tag in fields.get("tags", "").strip("[]").split(",")]
     tags = [tag for tag in tags if tag][:MAX_INDEX_TAGS]
@@ -1645,11 +1666,6 @@ def main() -> int:  # noqa: C901 — single-function CLI entry point
             _emit({"ok": False, "error": error, "artifacts": []})
             return code
 
-        error, code = atomic_replace(index_path, index_content, index_before)
-        if error:
-            _emit({"ok": False, "error": error, "artifacts": []})
-            return code
-
         if trackers_before == 0:
             error, code = atomic_replace(
                 state_path,
@@ -1660,6 +1676,15 @@ def main() -> int:  # noqa: C901 — single-function CLI entry point
             if error:
                 _emit({"ok": False, "error": error, "artifacts": []})
                 return code
+
+        # Written last, and deliberately after STATE.md: INDEX.md is fully
+        # derivable from the checkpoints and is rebuilt on the next run, so a
+        # concurrent-modification abort here must not leave the repository with
+        # a checkpoint and a PROGRESS.md entry but no tracker link.
+        error, code = atomic_replace(index_path, index_content, index_before)
+        if error:
+            _emit({"ok": False, "error": error, "artifacts": []})
+            return code
 
         payload["artifacts"] = [
             _rel(checkpoint_path, root),

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -703,6 +704,137 @@ def test_the_index_is_never_mistaken_for_a_checkpoint(project: Path) -> None:
 
     assert stems == [STAMP]
     assert "INDEX" not in (project / "PROGRESS.md").read_text(encoding="utf-8")
+
+
+# --- fast retrieval: tags, escaping, regeneration ----------------------------
+
+
+def test_tags_name_the_commit_types_and_directories_touched() -> None:
+    """The index is searched by tag, so tags must describe the session."""
+    collected = cp.Collected(
+        commits=[{"message": "feat: add index"}, {"message": "fix: escape pipes"}],
+        file_changes={
+            "created": [".agents/skills/catchup/collect_repo_state.py"],
+            "modified": ["tests/test_checkpoint.py"],
+            "deleted": [],
+        },
+        cli_entries=[{"tool": "codex"}],
+    )
+
+    tags = cp.derive_tags(collected)
+
+    assert {"feature", "bugfix", "tests", "testing", "skills", "codex"} <= set(tags)
+    assert tags == sorted(tags)
+
+
+def test_a_tag_cannot_break_the_frontmatter_flow_sequence() -> None:
+    """`tags: [a, #b]` is a fatal YAML parse error: `, #` opens a comment.
+
+    Tags come from directory and Agent Teams session names, so the characters
+    that can arrive are not under this script's control.
+    """
+    collected = cp.Collected(
+        file_changes={
+            "created": ["#weird/x.py", "&anchor/y.py", "{brace}/z.py"],
+            "modified": [],
+            "deleted": [],
+        },
+        teams_data=[{"name": 'a: b *alias'}],
+    )
+
+    tags = cp.derive_tags(collected)
+
+    assert tags, tags
+    for tag in tags:
+        assert re.fullmatch(r"[A-Za-z0-9._/-]+", tag), tag
+    assert "team-a-b-alias" in tags
+
+
+def test_a_pipe_in_the_summary_stays_inside_its_index_column() -> None:
+    row = cp._index_row(
+        "2026-01-01-000000",
+        {"slug": "s", "branch": "a|b", "summary": "add x | drop y", "commits": "1"},
+    )
+
+    cells = re.split(r"(?<!\\)\|", row)
+
+    assert len(cells) == 8, row  # 6 cells plus the outer empties
+    assert "add x \\| drop y" in row
+    assert "a\\|b" in row
+
+
+def test_a_bracket_in_the_slug_cannot_break_the_index_link() -> None:
+    """A hand-edited frontmatter must not destroy the catalog's only link."""
+    row = cp._index_row("2026-01-01-000000", {"slug": "broken] (x"})
+
+    assert row.count("](") == 1, row
+    assert "](2026-01-01-000000.md)" in row
+
+
+def test_an_unterminated_frontmatter_block_yields_no_fields() -> None:
+    """Without a closing fence a body line is indistinguishable from a field."""
+    text = "---\nslug: real\n\n# Checkpoint\n\ncommits: 999\nsummary: injected\n"
+
+    assert cp.parse_frontmatter(text) == {}
+    assert cp.parse_frontmatter("---\nslug: real\n---\n\n# C\ncommits: 999\n") == {
+        "slug": "real"
+    }
+
+
+def test_regenerating_the_index_is_byte_identical(project: Path) -> None:
+    """The catalog is rebuilt on every run; drift would be invisible."""
+    run(project, *summary_flag(project), "--apply")
+    on_disk = (project / ".agents" / "checkpoints" / "INDEX.md").read_text(
+        encoding="utf-8"
+    )
+
+    first = cp.compose_index_md(project)
+    second = cp.compose_index_md(project)
+
+    assert first == second
+    assert first == on_disk
+
+
+def test_a_failed_index_write_does_not_orphan_the_state_tracker(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INDEX.md is derivable and rebuilt next run; the tracker link is not.
+
+    Aborting the whole run on a stale index used to leave a checkpoint and a
+    PROGRESS.md entry with nothing in STATE.md pointing at them.
+    """
+    real_atomic_replace = cp.atomic_replace
+
+    def failing(path: Path, new_text: str, original_text, validate=None):
+        if path.name == cp.INDEX_FILENAME:
+            return f"{path.name} was modified concurrently; aborting", 3
+        return real_atomic_replace(path, new_text, original_text, validate)
+
+    monkeypatch.setattr(cp, "atomic_replace", failing)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "checkpoint.py",
+            "--project-root",
+            str(project),
+            "--claude-home",
+            str(project / "claude-home"),
+            "--now",
+            NOW,
+            "--json",
+            *summary_flag(project),
+            "--apply",
+        ],
+    )
+
+    assert cp.main() == 3
+    state = (project / ".agents" / "STATE.md").read_text(encoding="utf-8")
+    progress = (project / "PROGRESS.md").read_text(encoding="utf-8")
+    assert (project / ".agents" / "checkpoints" / f"{STAMP}.md").exists()
+    assert STAMP in progress, progress
+    assert "## Progress Tracker" in state, state
+    assert "PROGRESS.md" in state, state
 
 
 # --- CLI contract ------------------------------------------------------------

--- a/tests/test_collect_repo_state.py
+++ b/tests/test_collect_repo_state.py
@@ -344,6 +344,47 @@ def test_only_timestamp_named_checkpoints_are_listed(project: Path) -> None:
     assert [item["file"] for item in payload["items"]] == ["2026-07-25-100000.md"]
 
 
+def test_a_checkpoint_is_named_by_its_frontmatter_not_by_the_fence(
+    project: Path,
+) -> None:
+    """Since checkpoints gained a `---` block their first non-empty line is the
+    fence, which names no session. `first_line` must carry the summary instead.
+    """
+    checkpoints = project / ".agents" / "checkpoints"
+    checkpoints.mkdir(parents=True)
+    (checkpoints / "2026-07-25-100000.md").write_text(
+        "---\n"
+        "id: index-2026-07-25-100000\n"
+        "slug: index\n"
+        'summary: "add \\"fast\\" retrieval"\n'
+        "tags: [feature]\n"
+        "---\n"
+        "\n"
+        "# Checkpoint 2026-07-25-100000\n",
+        encoding="utf-8",
+    )
+    (checkpoints / "2026-07-24-100000.md").write_text(
+        "---\nslug: only-a-slug\n---\n\n# Checkpoint\n", encoding="utf-8"
+    )
+    (checkpoints / "2026-07-23-100000.md").write_text(
+        "# Legacy checkpoint\n", encoding="utf-8"
+    )
+    (checkpoints / "2026-07-22-100000.md").write_text(
+        "---\nslug: unterminated\n\n# Body heading\n", encoding="utf-8"
+    )
+
+    items = json.loads(run(project).stdout)["checkpoints"]["items"]
+    named = {item["file"]: item["first_line"] for item in items}
+
+    assert named["2026-07-25-100000.md"] == 'add "fast" retrieval'
+    assert named["2026-07-24-100000.md"] == "only-a-slug"
+    assert named["2026-07-23-100000.md"] == "# Legacy checkpoint"
+    assert named["2026-07-22-100000.md"] == "---"
+    assert "---" not in {
+        named[key] for key in named if key != "2026-07-22-100000.md"
+    }
+
+
 def test_an_unreadable_rule_file_is_reported_not_blank(project: Path) -> None:
     rules = project / ".agents" / "rules"
     rules.mkdir(parents=True)

--- a/tests/test_hook_thresholds.py
+++ b/tests/test_hook_thresholds.py
@@ -1,0 +1,199 @@
+"""Boundary tests for the hook thresholds changed in PR #35.
+
+Each hook gets one prompt/payload that must fire and one that must not. The
+no-fire half is the point: every defect these tests guard against was a hint
+that fired on a successful command, a benign prompt, or an ordinary edit, and
+a hint that fires on everything is one the operator learns to skim past.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIR = REPO_ROOT / ".agents" / "hooks"
+
+
+def load_hook(filename: str) -> ModuleType:
+    """Import a hyphenated hook script by path (not a valid module name)."""
+    module_name = filename.removesuffix(".py").replace("-", "_")
+    spec = importlib.util.spec_from_file_location(module_name, HOOKS_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+agent_router = load_hook("agent-router.py")
+check_before_write = load_hook("check-codex-before-write.py")
+error_to_codex = load_hook("error-to-codex.py")
+post_test_analysis = load_hook("post-test-analysis.py")
+post_impl_review = load_hook("post-implementation-review.py")
+
+
+def bash_payload(command: str, stdout: str) -> dict:
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": {"stdout": stdout, "stderr": "", "interrupted": False},
+    }
+
+
+# --- agent-router.py -------------------------------------------------------
+
+
+def test_detect_agent_with_genuine_design_question_routes_to_codex():
+    agent, trigger = agent_router.detect_agent(
+        "How should I design the retry layer? I am not sure about the trade-off."
+    )
+    assert agent == "codex"
+    assert trigger in {"design", "not sure", "trade-off"}
+
+
+def test_detect_agent_with_mechanical_ask_does_not_route():
+    assert agent_router.detect_agent("add a --dry-run option to the CLI") == (None, "")
+    assert agent_router.detect_agent("make the docstring better") == (None, "")
+    assert agent_router.detect_agent("相談なんだけど昼食は?") == (None, "")
+
+
+def test_detect_agent_with_two_character_japanese_prompt_still_routes():
+    """The deleted `len(prompt) < 3` gate skipped exactly this prompt."""
+    agent, trigger = agent_router.detect_agent("設計")
+    assert (agent, trigger) == ("codex", "設計")
+
+
+# --- check-codex-before-write.py -------------------------------------------
+
+
+def test_should_suggest_codex_for_large_new_written_file():
+    suggest, reason = check_before_write.should_suggest_codex(
+        "/repo/tools/helper.py", "x = 1\n" * 200, is_new_file=True
+    )
+    assert suggest is True
+    assert "new file" in reason
+
+
+def test_should_suggest_codex_not_for_medium_prose_edit():
+    """Boundary: 210 characters of an Edit is a paragraph, not a new file."""
+    suggest, reason = check_before_write.should_suggest_codex(
+        "/repo/docs/notes.md", "a" * 210, is_new_file=False
+    )
+    assert (suggest, reason) == (False, "")
+
+
+def test_should_suggest_codex_ignores_build_artefact_paths():
+    suggest, _ = check_before_write.should_suggest_codex("/repo/__pycache__/x.pyc", "")
+    assert suggest is False
+
+
+def test_should_suggest_codex_counts_only_real_definitions():
+    suggest, _ = check_before_write.should_suggest_codex(
+        "/repo/x.h", "typedef struct A A;\ntypedef struct B B;\n"
+    )
+    assert suggest is False
+
+    suggest, reason = check_before_write.should_suggest_codex(
+        "/repo/x.py", "def alpha():\n    pass\n\ndef beta():\n    pass\n"
+    )
+    assert suggest is True
+    assert "definitions" in reason
+
+
+# --- error-to-codex.py -----------------------------------------------------
+
+
+def test_error_hook_fires_on_real_traceback():
+    context = error_to_codex.build_context(
+        bash_payload(
+            "python3 script.py",
+            'Traceback (most recent call last):\n  File "s.py", line 1\n'
+            "ValueError: bad input\n",
+        )
+    )
+    assert context is not None
+    assert "[Error Detected]" in context
+
+
+def test_error_hook_quiet_on_two_weak_signals():
+    """Boundary: MIN_WEAK_SIGNALS is 3, so a deprecation plus a "Could not"
+    that a healthy pip install prints must not be enough."""
+    context = error_to_codex.build_context(
+        bash_payload(
+            "uv pip install requests",
+            "Could not find a cached wheel, building from source\n"
+            "Retrying after the request timed out\n"
+            "Successfully installed requests-2.32.3\n",
+        )
+    )
+    assert context is None
+
+
+# --- post-test-analysis.py -------------------------------------------------
+
+
+def test_test_analysis_fires_on_red_suite():
+    context = post_test_analysis.build_context(
+        bash_payload(
+            "uv run pytest tests/",
+            "FAILED tests/test_foo.py::test_bar\n"
+            "E   assert 1 == 2\n"
+            "1 failed, 2 passed\n",
+        )
+    )
+    assert context is not None
+    assert "[Codex Debug Suggestion]" in context
+
+
+def test_test_analysis_quiet_on_green_suite_with_error_in_test_names():
+    context = post_test_analysis.build_context(
+        bash_payload(
+            "uv run pytest tests/ -v",
+            "tests/t.py::test_error_hint PASSED [ 50%]\n"
+            "tests/t.py::test_traceback_hint PASSED [100%]\n"
+            "8 passed in 0.30s\n",
+        )
+    )
+    assert context is None
+
+
+# --- post-implementation-review.py -----------------------------------------
+
+
+def test_should_suggest_review_at_the_file_threshold():
+    state = {"files_changed": ["a.py", "b.py"], "total_lines": 2}
+    suggest, reason = post_impl_review.should_suggest_review(state)
+    assert suggest is True
+    assert reason == "2 files modified"
+
+
+def test_should_suggest_review_below_the_file_threshold():
+    state = {"files_changed": ["a.py"], "total_lines": 1}
+    assert post_impl_review.should_suggest_review(state) == (False, "")
+
+
+def test_should_suggest_review_debounces_then_rearms_when_work_doubles():
+    """The one-shot latch let two one-line edits spend the session's only
+    nudge; the doubling rule keeps the debounce but re-arms for real work."""
+    state = {
+        "files_changed": ["a.py", "b.py", "c.py"],
+        "total_lines": 3,
+        "suggested_at_files": 2,
+        "suggested_at_lines": 2,
+    }
+    assert post_impl_review.should_suggest_review(state) == (False, "")
+
+    state["files_changed"].append("d.py")
+    suggest, reason = post_impl_review.should_suggest_review(state)
+    assert suggest is True
+    assert reason == "4 files modified"
+
+
+def test_review_hook_end_to_end_stays_quiet_on_a_single_file(tmp_path: Path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps({"files_changed": ["a.py"], "total_lines": 1}), encoding="utf-8"
+    )
+    state = post_impl_review.load_state(str(state_file))
+    assert post_impl_review.should_suggest_review(state) == (False, "")

--- a/tests/test_post_bash_check.py
+++ b/tests/test_post_bash_check.py
@@ -33,6 +33,13 @@ def run_dispatcher(
 
 
 def bash_hook_input(command: str, stdout: str, exit_code: int = 1) -> dict:
+    """Build a PostToolUse Bash payload.
+
+    ``exit_code`` is consumed by log-cli-tools.py only. A captured real payload
+    carries just ``{stdout, stderr, interrupted, isImage, noOutputExpected}``
+    under ``tool_response`` — and a failing Bash command does not reach the
+    hook at all — so no error-detection logic may key off it.
+    """
     return {
         "tool_name": "Bash",
         "tool_input": {"command": command},
@@ -212,6 +219,90 @@ def test_benign_output_produces_no_hint(tmp_path: Path) -> None:
     payload = bash_hook_input(
         command="ls -la",
         stdout="total 42\ndrwxr-xr-x  5 user user 4096 Jan 1 12:00 .\n",
+        exit_code=0,
+    )
+
+    result = run_dispatcher(hooks_dir, payload)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_green_pytest_output_produces_no_hint(tmp_path: Path) -> None:
+    """A passing suite must stay silent.
+
+    Regression guard: the bare `ERROR`/`failed`/`Error:` patterns matched the
+    word "error" inside test *names*, so this exact output — 8 passed, 0
+    failed — produced "Test failure with error details (2 issues)".
+    """
+    hooks_dir = build_isolated_hooks_dir(tmp_path)
+    payload = bash_hook_input(
+        command="uv run pytest tests/test_post_bash_check.py -v",
+        stdout=(
+            "tests/test_post_bash_check.py::test_traceback_output_triggers_"
+            "debugging_hint PASSED [ 12%]\n"
+            "tests/test_post_bash_check.py::test_pytest_failure_dedups_generic_"
+            "error_hint PASSED [ 25%]\n"
+            "tests/test_post_bash_check.py::test_benign_output_produces_no_hint "
+            "PASSED [ 87%]\n"
+            "============================== 8 passed in 0.30s "
+            "===============================\n"
+        ),
+        exit_code=0,
+    )
+
+    result = run_dispatcher(hooks_dir, payload)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_clean_mypy_output_on_errors_module_produces_no_hint(tmp_path: Path) -> None:
+    """Boundary case: a success message whose only "error" is a file name."""
+    hooks_dir = build_isolated_hooks_dir(tmp_path)
+    payload = bash_hook_input(
+        command="uv run mypy src/errors.py",
+        stdout="Success: no issues found in 1 source file (src/errors.py)\n",
+        exit_code=0,
+    )
+
+    result = run_dispatcher(hooks_dir, payload)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_benign_nonzero_exit_produces_no_hint(tmp_path: Path) -> None:
+    """`diff` reporting differences is an answer, not a failure.
+
+    Regression guard for the "command exited with code 1 - likely a silent
+    failure" branch, which fired on every loud non-zero exit. The branch is
+    gone (the real PostToolUse payload carries no exit status at all), and this
+    test keeps any replacement from re-introducing the behaviour.
+    """
+    hooks_dir = build_isolated_hooks_dir(tmp_path)
+    payload = bash_hook_input(
+        command="diff a.txt b.txt",
+        stdout="1c1\n< alpha\n---\n> beta\n",
+        exit_code=1,
+    )
+
+    result = run_dispatcher(hooks_dir, payload)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_deprecation_warnings_alone_produce_no_hint(tmp_path: Path) -> None:
+    """A warning is not an error, even when two of them travel together."""
+    hooks_dir = build_isolated_hooks_dir(tmp_path)
+    payload = bash_hook_input(
+        command="uv pip install requests",
+        stdout=(
+            "DEPRECATION: the legacy resolver is deprecated\n"
+            "Could not find a cached wheel, building from source\n"
+            "Successfully installed requests-2.32.3\n"
+        ),
         exit_code=0,
     )
 


### PR DESCRIPTION
## Why

PR #35 landed as `9d93caf` without the review this repository's own rules ask for. Its intent was sound — catch more of the cases that deserve Codex — but the thresholds it lowered made the hints fire on work that had not failed, and the frontmatter it added quietly broke a different skill. This PR supplies the review that was owed and fixes what it found.

Reproduced against the merged commit, not inferred:

- `uv run pytest tests/test_post_bash_check.py -v` → **8 passed** → hook emits `Test failure with error details (2 issues)`. The "issues" were the substring `error` in two test *names*.
- `diff a b` with differences (exit 1, four legitimate lines) → `command exited with code 1 - likely a silent failure`.
- `add a --dry-run option`, `make the docstring better`, `相談なんだけど昼食は?` → all routed, now worded as `MUST go through Codex`.
- Every checkpoint's `first_line` became `---`, so `/catchup`'s per-session signal was dead while `catchup/SKILL.md` still documented it as "file + first heading".

The hooks fired on their own verification runs several times during this work. A hint that fires on everything carries no signal.

## What changed

**Hooks.** Failure patterns anchored to line starts and made case-sensitive. The router drops the ambiguous single words (`option`, `pattern`, `improve`, `セキュリティ`, `相談`, …), keeps the multi-word phrases, and matches English on word boundaries; deleting its character-length gate finally lets `設計` through — the two-character case the gate claimed to rescue but skipped. Write/Edit stops reporting a prose edit as a file creation, counts definitions with a regex rather than `count("def ")`, and matches role words against path tokens so `__pycache__` no longer looks like a cache layer. Deprecation warnings stop counting as errors. `post-implementation-review` re-arms on a doubling instead of spending its only nudge on the first two one-line edits.

**The non-zero-exit branch is deleted, not repaired.** A captured live payload carries no exit-status field, and failing commands never reach the hook at all — four of them produced no invocation while every successful command in the same window did. `codex-delegation.md`'s table said otherwise and is corrected to match.

**Checkpointing / catchup.** `collect_repo_state.py` skips a leading frontmatter block and prefers its `summary`, then `slug`, over the first body line — reading the block itself rather than importing `checkpoint.py`, so the two skills stay decoupled. Alongside it: tags and index slugs go through an allow-list, so a directory or team name carrying `#`, `&`, `*` or `:` can no longer emit unparseable YAML or a broken markdown link; `INDEX.md`, being fully derivable, is written after the `STATE.md` tracker insert so its guard cannot orphan a checkpoint; and `parse_frontmatter` locates the closing fence before reading, so an unterminated block stops promoting body lines into fields.

**Tests.** 27 new tests covering exactly the paths that let this through — the green-run and benign-exit cases, per-hook fire/no-fire pairs, a frontmatter-bearing checkpoint fixture, and the special-character cases `.agents/rules/testing.md` asks for. No existing test was weakened, skipped, or removed.

## Verification

```
$ bash .agents/check.sh
Results: 8 passed, 0 failed

$ python3 .agents/skills/_shared/run_tests.py --expect pass --target tests/
{"observed": "passed", "summary": "994 passed in 90.56s", "failed_tests": [], "ok": true}
```

Behaviour, re-checked independently of the agents that wrote the fixes:

| | before | after |
|---|---|---|
| green `pytest -v` | fires | silent |
| `diff` at exit 1 | fires | silent |
| `add a --dry-run option` | routes | silent |
| `/catchup` `first_line` | `"---"` | `"real summary \| with pipe"` |
| red pytest | fires | **still fires** |
| real traceback | fires | **still fires** |
| `設計` | skipped | **now routes** |

## Caveat

**None of this is Codex-reviewed.** This environment's egress proxy answers `403` to `CONNECT` for `api.openai.com`, so `codex_consult.py` cannot reach the model — verified directly, not assumed. Every judgment call Codex would have arbitrated was replaced with an executable check instead, so the facts hold, but the severities and a handful of design calls (delete-vs-repair for the exit-code branch, the doubling re-arm rule, case-sensitive matching, including the parent directory in path tokens) are unreviewed and listed in the evidence files. The prompts are preserved verbatim under `.agents/logs/codex/` and replay unchanged once the host is reachable.

Reviews and evidence: `.agents/docs/reviews/pr35-{hooks,checkpointing}-{codex-review,fix-evidence}-2026-09-03.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BS1WWqXUB19GUaPTF1uYuw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BS1WWqXUB19GUaPTF1uYuw)_